### PR TITLE
Hotfix/hanging empty filesystems

### DIFF
--- a/zfs_autobackup
+++ b/zfs_autobackup
@@ -186,7 +186,7 @@ def zfs_get_snapshots(ssh_to, filesystems, backup_name):
                             ret[filesystem]=[]
                         ret[filesystem].extend(test_snapshots[ssh_to][filesystem])
 
-    return(ret)
+        return(ret)
 
 
 

--- a/zfs_autobackup
+++ b/zfs_autobackup
@@ -164,26 +164,27 @@ return[filesystem_name]=[ "snashot1", "snapshot2", ... ]
 """
 def zfs_get_snapshots(ssh_to, filesystems, backup_name):
 
-    snapshots=run(ssh_to=ssh_to, input="\0".join(filesystems), valid_exitcodes=[ 0,1 ], cmd=
-        [ "xargs", "-0", "-n", "1", "zfs", "list", "-d", "1", "-r", "-t" ,"snapshot", "-H", "-o", "name" ]
-    )
+    if filesystems:
+        snapshots=run(ssh_to=ssh_to, input="\0".join(filesystems), valid_exitcodes=[ 0,1 ], cmd=
+            [ "xargs", "-0", "-n", "1", "zfs", "list", "-d", "1", "-r", "-t" ,"snapshot", "-H", "-o", "name" ]
+        )
 
-    ret={}
-    for snapshot in snapshots:
-        (filesystem, snapshot_name)=snapshot.split("@")
-        if re.match("^"+backup_name+"-[0-9]*$", snapshot_name):
-            if not filesystem in ret:
-                ret[filesystem]=[]
-            ret[filesystem].append(snapshot_name)
+        ret={}
+        for snapshot in snapshots:
+            (filesystem, snapshot_name)=snapshot.split("@")
+            if re.match("^"+backup_name+"-[0-9]*$", snapshot_name):
+                if not filesystem in ret:
+                    ret[filesystem]=[]
+                ret[filesystem].append(snapshot_name)
 
-    #also add any test-snapshots that where created with --test mode
-    if args.test:
-        if ssh_to in test_snapshots:
-            for filesystem in filesystems:
-                if filesystem in test_snapshots[ssh_to]:
-                    if not filesystem in ret:
-                        ret[filesystem]=[]
-                    ret[filesystem].extend(test_snapshots[ssh_to][filesystem])
+        #also add any test-snapshots that where created with --test mode
+        if args.test:
+            if ssh_to in test_snapshots:
+                for filesystem in filesystems:
+                    if filesystem in test_snapshots[ssh_to]:
+                        if not filesystem in ret:
+                            ret[filesystem]=[]
+                        ret[filesystem].extend(test_snapshots[ssh_to][filesystem])
 
     return(ret)
 

--- a/zfs_autobackup
+++ b/zfs_autobackup
@@ -164,12 +164,13 @@ return[filesystem_name]=[ "snashot1", "snapshot2", ... ]
 """
 def zfs_get_snapshots(ssh_to, filesystems, backup_name):
 
+    ret={}
+
     if filesystems:
         snapshots=run(ssh_to=ssh_to, input="\0".join(filesystems), valid_exitcodes=[ 0,1 ], cmd=
             [ "xargs", "-0", "-n", "1", "zfs", "list", "-d", "1", "-r", "-t" ,"snapshot", "-H", "-o", "name" ]
         )
 
-        ret={}
         for snapshot in snapshots:
             (filesystem, snapshot_name)=snapshot.split("@")
             if re.match("^"+backup_name+"-[0-9]*$", snapshot_name):
@@ -186,7 +187,7 @@ def zfs_get_snapshots(ssh_to, filesystems, backup_name):
                             ret[filesystem]=[]
                         ret[filesystem].extend(test_snapshots[ssh_to][filesystem])
 
-        return(ret)
+    return(ret)
 
 
 


### PR DESCRIPTION
Fixed zfs_get_snapshots hang when filesystems is an empty list.

Seem to occur only when send is disabled.