### PR TITLE
use python -u to stop buffering

### DIFF
--- a/bin/zfs-autobackup
+++ b/bin/zfs-autobackup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env -S python -u
 # -*- coding: utf8 -*-
 
 # (c)edwin@datux.nl  - Released under GPL


### PR DESCRIPTION
Disables stdin/stdout/stderr buffering, which allows zfs_autobackup to write to a log file synchronously (instead of by chunks)