### PR TITLE
Add security warning & workaround for dangling SSH connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Host *
     ControlPersist 3600
 ```
 
+**Warning**: This will leave your SSH connection open for an hour even after the backup exists. Make sure to run `ssh -O exit smartos04` after you run zfs-autobackup to close it.
+
 Thanks @mariusvw :)
 
 ### Specifying ssh port or options


### PR DESCRIPTION
Leaving the SSH connection open for an hour improves backup speed greatly but it also means the connection will remain open after your backup is done. SSH connections can be exploited both ways (an attacker can use [remote port forwarding](https://mwl.io/archives/945) to access your backup server if they break into your remote server) so it's better to close them when not needed. :-)