### PR TITLE
WIP: Initial ZFS clones support

### DIFF
--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -372,6 +372,9 @@ class ZfsAutobackup:
         :type source_node: ZfsNode
         """
 
+        def make_target_name(source_dataset):
+            return self.args.target_path + "/" + source_dataset.lstrip_path(self.args.strip_path)
+
         send_pipes = self.get_send_pipes(source_node.verbose)
         recv_pipes = self.get_recv_pipes(target_node.verbose)
 
@@ -387,7 +390,7 @@ class ZfsAutobackup:
 
             try:
                 # determine corresponding target_dataset
-                target_name = self.args.target_path + "/" + source_dataset.lstrip_path(self.args.strip_path)
+                target_name = make_target_name(source_dataset)
                 target_dataset = ZfsDataset(target_node, target_name)
                 target_datasets.append(target_dataset)
 
@@ -414,7 +417,8 @@ class ZfsAutobackup:
                                               destroy_incompatible=self.args.destroy_incompatible,
                                               send_pipes=send_pipes, recv_pipes=recv_pipes,
                                               decrypt=self.args.decrypt, encrypt=self.args.encrypt,
-                                              zfs_compressed=self.args.zfs_compressed)
+                                              zfs_compressed=self.args.zfs_compressed,
+                                              make_target_name=make_target_name)
             except Exception as e:
                 fail_count = fail_count + 1
                 source_dataset.error("FAILED: " + str(e))

--- a/zfs_autobackup/ZfsNode.py
+++ b/zfs_autobackup/ZfsNode.py
@@ -1,5 +1,6 @@
 # python 2 compatibility
 from __future__ import print_function
+from operator import attrgetter
 import re
 import shlex
 import subprocess
@@ -219,15 +220,15 @@ class ZfsNode(ExecuteNode):
     def selected_datasets(self, property_name, exclude_received, exclude_paths, exclude_unchanged, min_change):
         """determine filesystems that should be backed up by looking at the special autobackup-property, systemwide
 
-           returns: list of ZfsDataset
+           returns: list of ZfsDataset sorted by creation time
         """
 
         self.debug("Getting selected datasets")
 
         # get all source filesystems that have the backup property
         lines = self.run(tab_split=True, readonly=True, cmd=[
-            "zfs", "get", "-t", "volume,filesystem", "-o", "name,value,source", "-H",
-            property_name
+            "zfs", "get", "-t", "volume,filesystem", "-Hp",
+            "{},creation".format(property_name)
         ])
 
         # The returnlist of selected ZfsDataset's:
@@ -237,23 +238,27 @@ class ZfsNode(ExecuteNode):
         sources = {}
 
         for line in lines:
-            (name, value, raw_source) = line
-            dataset = ZfsDataset(self, name)
+            (name, prop_name, value, raw_source) = line
+            if prop_name == property_name:
+                dataset = ZfsDataset(self, name)
 
-            # "resolve" inherited sources
-            sources[name] = raw_source
-            if raw_source.find("inherited from ") == 0:
-                inherited = True
-                inherited_from = re.sub("^inherited from ", "", raw_source)
-                source = sources[inherited_from]
-            else:
-                inherited = False
-                source = raw_source
+                # "resolve" inherited sources
+                sources[name] = raw_source
+                if raw_source.find("inherited from ") == 0:
+                    inherited = True
+                    inherited_from = re.sub("^inherited from ", "", raw_source)
+                    source = sources[inherited_from]
+                else:
+                    inherited = False
+                    source = raw_source
 
-            # determine it
-            if dataset.is_selected(value=value, source=source, inherited=inherited, exclude_received=exclude_received,
-                                   exclude_paths=exclude_paths, exclude_unchanged=exclude_unchanged,
-                                   min_change=min_change):
-                selected_filesystems.append(dataset)
-
-        return selected_filesystems
+                # determine it
+                if dataset.is_selected(value=value, source=source, inherited=inherited, exclude_received=exclude_received,
+                                       exclude_paths=exclude_paths, exclude_unchanged=exclude_unchanged,
+                                       min_change=min_change):
+                    selected_filesystems.append(dataset)
+            elif prop_name == "creation":
+                # creation date for the last dataset
+                if selected_filesystems and selected_filesystems[-1].name == name:
+                    selected_filesystems[-1].creation = int(value)
+        return sorted(selected_filesystems, key=attrgetter("creation"))


### PR DESCRIPTION
This adds initial support for ZFS clones (#36). The datasets are now synced in `creation` order, thus any clone comes after its origin. If a clone dataset is selected for sync, its origin snapshot must already exist on the target node. If it's not the case, an error occurs, and user is given a suggestion to retransfer the origin dataset with `--other-snapshots`.