### PR TITLE
Support for zstd-adapt

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,9 +619,9 @@ optional arguments:
                         multiple times)
   --recv-pipe COMMAND   pipe zfs recv input through COMMAND (can be used
                         multiple times)
-  --compress TYPE       Use compression during transfer, zstd-fast
-                        recommended. (xz, pigz-slow, zstd-slow, zstd-fast,
-                        lzo, gzip, pigz-fast, lz4)
+  --compress TYPE       Use compression during transfer, defaults to zstd-adapt
+                        if TYPE is not specified. (gzip, pigz-fast, pigz-slow,
+                        zstd-fast, zstd-slow, zstd-adapt, xz, lzo, lz4)
   --rate DATARATE       Limit data transfer rate (e.g. 128K. requires
                         mbuffer.)
   --buffer SIZE         Add zfs send and recv buffers to smooth out IO bursts.

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -129,7 +129,7 @@ class ZfsAutobackup:
                             help='pipe zfs send output through COMMAND (can be used multiple times)')
         parser.add_argument('--recv-pipe', metavar="COMMAND", default=[], action='append',
                             help='pipe zfs recv input through COMMAND (can be used multiple times)')
-        parser.add_argument('--compress', metavar='TYPE', default=None, choices=compressors.choices(), help='Use compression during transfer, zstd-fast recommended. ({})'.format(", ".join(compressors.choices())))
+        parser.add_argument('--compress', metavar='TYPE', default=None, nargs='?', const='zstd-adapt', choices=compressors.choices(), help='Use compression during transfer, defaults to zstd-adapt if TYPE is not specified. ({})'.format(", ".join(compressors.choices())))
         parser.add_argument('--rate', metavar='DATARATE', default=None, help='Limit data transfer rate (e.g. 128K. requires mbuffer.)')
         parser.add_argument('--buffer', metavar='SIZE', default=None, help='Add zfs send and recv buffers to smooth out IO bursts. (e.g. 128M. requires mbuffer)')
 

--- a/zfs_autobackup/compressors.py
+++ b/zfs_autobackup/compressors.py
@@ -35,6 +35,12 @@ COMPRESS_CMDS = {
         'dcmd': 'zstdmt',
         'dargs': [ '-dc' ],
     },
+    'zstd-adapt': {
+        'cmd': 'zstdmt',
+        'args': [ '--adapt' ],
+        'dcmd': 'zstdmt',
+        'dargs': [ '-dc' ],
+    },
     'xz': {
         'cmd': 'xz',
         'args': [],


### PR DESCRIPTION
pull request for #89

- support for `zstd-adapt`
- default to `zstd-adapt` when `--compress` is specified without a type
- extend readme with `zstd-adapt` and fix order of compressor choices to be the same as returned by `--help`