### PR TITLE
Fix MB/s calculations on multiple transfers

### DIFF
--- a/zfs_autobackup/ZfsNode.py
+++ b/zfs_autobackup/ZfsNode.py
@@ -132,9 +132,15 @@ class ZfsNode(ExecuteNode):
             # actual useful info
             if len(progress_fields) >= 3:
                 if progress_fields[0] == 'full' or progress_fields[0] == 'size':
+		    # Reset the total bytes and start the timer again (otherwise the MB/s
+		    # counter gets confused)
                     self._progress_total_bytes = int(progress_fields[2])
+                    self._progress_start_time = time.time()
                 elif progress_fields[0] == 'incremental':
+		    # Reset the total bytes and start the timer again (otherwise the MB/s
+		    # counter gets confused)
                     self._progress_total_bytes = int(progress_fields[3])
+                    self._progress_start_time = time.time()
                 elif progress_fields[1].isnumeric():
                     bytes_ = int(progress_fields[1])
                     if self._progress_total_bytes:


### PR DESCRIPTION
If you have multiple snapshots being transferred, the MB/s calcs are wrong, because
it's using the start time of the connection, rather than the start time of this specific
snapshot.