### PR TITLE
Add --snapshot-property argument to pass to zfs snapshot

### DIFF
--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -67,8 +67,8 @@ class ZfsAutobackup(ZfsAuto):
                            help='If nothing has changed, still create empty snapshots. (Faster. Same as --min-change=0)')
         group.add_argument('--other-snapshots', action='store_true',
                            help='Send over other snapshots as well, not just the ones created by this tool.')
-        group.add_argument('--snapshot-property', metavar='PROPERTY=VALUE', default=None,
-                           help='Property to set during snapshot (argument to zfs snapshot)')
+        group.add_argument('--set-snapshot-properties', metavar='PROPERTY=VALUE,...', type=str,
+                           help='List of properties to set on the snapshot.')
 
 
         group = parser.add_argument_group("Transfer options")
@@ -385,6 +385,15 @@ class ZfsAutobackup(ZfsAuto):
 
         return set_properties
 
+    def set_snapshot_properties_list(self):
+
+        if self.args.set_snapshot_properties:
+            set_snapshot_properties = self.args.set_snapshot_properties.split(",")
+        else:
+            set_snapshot_properties = []
+
+        return set_snapshot_properties
+
     def run(self):
 
         try:
@@ -421,7 +430,7 @@ class ZfsAutobackup(ZfsAuto):
                                                 min_changed_bytes=self.args.min_change,
                                                 pre_snapshot_cmds=self.args.pre_snapshot_cmd,
                                                 post_snapshot_cmds=self.args.post_snapshot_cmd,
-                                                snapshot_property=self.args.snapshot_property)
+                                                set_snapshot_properties=self.set_snapshot_properties_list())
 
             ################# sync
             # if target is specified, we sync the datasets, otherwise we just thin the source. (e.g. snapshot mode)

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -67,6 +67,9 @@ class ZfsAutobackup(ZfsAuto):
                            help='If nothing has changed, still create empty snapshots. (Faster. Same as --min-change=0)')
         group.add_argument('--other-snapshots', action='store_true',
                            help='Send over other snapshots as well, not just the ones created by this tool.')
+        group.add_argument('--snapshot-property', metavar='PROPERTY=VALUE', default=None,
+                           help='Property to set during snapshot (argument to zfs snapshot)')
+
 
         group = parser.add_argument_group("Transfer options")
         group.add_argument('--no-send', action='store_true',
@@ -417,7 +420,8 @@ class ZfsAutobackup(ZfsAuto):
                 source_node.consistent_snapshot(source_datasets, snapshot_name,
                                                 min_changed_bytes=self.args.min_change,
                                                 pre_snapshot_cmds=self.args.pre_snapshot_cmd,
-                                                post_snapshot_cmds=self.args.post_snapshot_cmd)
+                                                post_snapshot_cmds=self.args.post_snapshot_cmd,
+                                                snapshot_property=self.args.snapshot_property)
 
             ################# sync
             # if target is specified, we sync the datasets, otherwise we just thin the source. (e.g. snapshot mode)

--- a/zfs_autobackup/ZfsNode.py
+++ b/zfs_autobackup/ZfsNode.py
@@ -174,7 +174,7 @@ class ZfsNode(ExecuteNode):
         self.logger.debug("{} {}".format(self.description, txt))
 
     def consistent_snapshot(self, datasets, snapshot_name, min_changed_bytes, pre_snapshot_cmds=[],
-                            post_snapshot_cmds=[]):
+                            post_snapshot_cmds=[], snapshot_property=None):
         """create a consistent (atomic) snapshot of specified datasets, per pool.
         """
 
@@ -212,6 +212,8 @@ class ZfsNode(ExecuteNode):
             # create consistent snapshot per pool
             for (pool_name, snapshots) in pools.items():
                 cmd = ["zfs", "snapshot"]
+                if snapshot_property:
+                    cmd += ['-o', snapshot_property]
 
                 cmd.extend(map(lambda snapshot_: str(snapshot_), snapshots))
 

--- a/zfs_autobackup/ZfsNode.py
+++ b/zfs_autobackup/ZfsNode.py
@@ -212,7 +212,7 @@ class ZfsNode(ExecuteNode):
             # create consistent snapshot per pool
             for (pool_name, snapshots) in pools.items():
                 cmd = ["zfs", "snapshot"]
-                for snapshot_property in set_snapshot_properties
+                for snapshot_property in set_snapshot_properties:
                     cmd += ['-o', snapshot_property]
 
                 cmd.extend(map(lambda snapshot_: str(snapshot_), snapshots))

--- a/zfs_autobackup/ZfsNode.py
+++ b/zfs_autobackup/ZfsNode.py
@@ -174,7 +174,7 @@ class ZfsNode(ExecuteNode):
         self.logger.debug("{} {}".format(self.description, txt))
 
     def consistent_snapshot(self, datasets, snapshot_name, min_changed_bytes, pre_snapshot_cmds=[],
-                            post_snapshot_cmds=[], snapshot_property=None):
+                            post_snapshot_cmds=[], set_snapshot_properties=[]):
         """create a consistent (atomic) snapshot of specified datasets, per pool.
         """
 
@@ -212,7 +212,7 @@ class ZfsNode(ExecuteNode):
             # create consistent snapshot per pool
             for (pool_name, snapshots) in pools.items():
                 cmd = ["zfs", "snapshot"]
-                if snapshot_property:
+                for snapshot_property in set_snapshot_properties
                     cmd += ['-o', snapshot_property]
 
                 cmd.extend(map(lambda snapshot_: str(snapshot_), snapshots))


### PR DESCRIPTION
Just exposing the property argument of zfs snapshot

From zfs snapshot man page:

```
     zfs snapshot [-r] [-o property=value]… dataset@snapname…

     -o property=value
         Set the specified property; see zfs create for details.
```


This is a different effect than changing a property on received. Also not the same as a pre-snapshot `zfs set`. A possible use-case is tracking info that should live with the atomic snapshot.

Example of pulling snapshots from different nodes and tracking where the snapshot came from
```
NAME                                              USED  WRITTEN:BY
rpool/DATA/project@data-2022-06-12_22-44-42        64K  node1
rpool/DATA/project@data-2022-06-12_22-45-41        64K  node2
rpool/DATA/project@data-2022-06-12_22-47-02        72K  node1
rpool/DATA/project@data-2022-06-12_22-48-17         0B  node3
```