### PR TITLE
Added --send-delay option, fixes race condition with direct TCP transfer

### DIFF
--- a/zfs_autobackup/ExecuteNode.py
+++ b/zfs_autobackup/ExecuteNode.py
@@ -18,6 +18,7 @@ class ExecuteNode(LogStub):
     """an endpoint to execute local or remote commands via ssh"""
 
     PIPE=1
+    AND=2
 
     def __init__(self, ssh_config=None, ssh_to=None, readonly=False, debug_output=False):
         """ssh_config: custom ssh config
@@ -53,6 +54,8 @@ class ExecuteNode(LogStub):
         """return quoted version of command. if it has value PIPE it will add an actual | """
         if cmd==self.PIPE:
             return('|')
+        elif cmd==self.AND:
+            return('&&')
         else:
             return cmd_quote(cmd)
 

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -123,6 +123,8 @@ class ZfsAutobackup(ZfsAuto):
                            help='pipe zfs send output through COMMAND (can be used multiple times)')
         group.add_argument('--recv-pipe', metavar="COMMAND", default=[], action='append',
                            help='pipe zfs recv input through COMMAND (can be used multiple times)')
+        group.add_argument('--send-delay', metavar='SECONDS', default=0, type=int,
+                           help='Add a delay to the zfs send command')
 
         group = parser.add_argument_group("Thinner options")
         group.add_argument('--no-thinning', action='store_true', help="Do not destroy any snapshots.")
@@ -360,7 +362,8 @@ class ZfsAutobackup(ZfsAuto):
                                               destroy_incompatible=self.args.destroy_incompatible,
                                               send_pipes=send_pipes, recv_pipes=recv_pipes,
                                               decrypt=self.args.decrypt, encrypt=self.args.encrypt,
-                                              zfs_compressed=self.args.zfs_compressed, force=self.args.force)
+                                              zfs_compressed=self.args.zfs_compressed, force=self.args.force,
+                                              send_delay=self.args.send_delay)
             except Exception as e:
                 # if self.args.progress:
                 #     self.clear_progress()

--- a/zfs_autobackup/ZfsDataset.py
+++ b/zfs_autobackup/ZfsDataset.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 from .CachedProperty import CachedProperty
-from .ExecuteNode import ExecuteError
+from .ExecuteNode import ExecuteError, ExecuteNode
 
 
 class ZfsDataset:
@@ -556,7 +556,7 @@ class ZfsDataset:
 
         return self.from_names(names[1:])
 
-    def send_pipe(self, features, prev_snapshot, resume_token, show_progress, raw, send_properties, write_embedded, send_pipes, zfs_compressed):
+    def send_pipe(self, features, prev_snapshot, resume_token, show_progress, raw, send_properties, write_embedded, send_pipes, zfs_compressed, send_delay=0):
         """returns a pipe with zfs send output for this snapshot
 
         resume_token: resume sending from this token. (in that case we don't
@@ -573,6 +573,10 @@ class ZfsDataset:
         """
         # build source command
         cmd = []
+
+        # Pause before zfs send in case the zfs recv end needs to complete any setup, e.g. starting a netcat listener
+        if send_delay > 0:
+            cmd.extend(["sleep", str(send_delay), ExecuteNode.AND])
 
         cmd.extend(["zfs", "send", ])
 
@@ -691,7 +695,7 @@ class ZfsDataset:
 
     def transfer_snapshot(self, target_snapshot, features, prev_snapshot, show_progress,
                           filter_properties, set_properties, ignore_recv_exit_code, resume_token,
-                          raw, send_properties, write_embedded, send_pipes, recv_pipes, zfs_compressed, force):
+                          raw, send_properties, write_embedded, send_pipes, recv_pipes, zfs_compressed, force, send_delay):
         """transfer this snapshot to target_snapshot. specify prev_snapshot for
         incremental transfer
 
@@ -709,6 +713,7 @@ class ZfsDataset:
             :type ignore_recv_exit_code: bool
             :type resume_token: str
             :type raw: bool
+            :type send_delay: int
         """
 
         if set_properties is None:
@@ -730,7 +735,8 @@ class ZfsDataset:
 
         # do it
         pipe = self.send_pipe(features=features, show_progress=show_progress, prev_snapshot=prev_snapshot,
-                              resume_token=resume_token, raw=raw, send_properties=send_properties, write_embedded=write_embedded, send_pipes=send_pipes, zfs_compressed=zfs_compressed)
+                              resume_token=resume_token, raw=raw, send_properties=send_properties, write_embedded=write_embedded,
+                              send_pipes=send_pipes, zfs_compressed=zfs_compressed, send_delay=send_delay)
         target_snapshot.recv_pipe(pipe, features=features, filter_properties=filter_properties,
                                   set_properties=set_properties, ignore_exit_code=ignore_recv_exit_code, recv_pipes=recv_pipes, force=force)
 
@@ -1023,7 +1029,7 @@ class ZfsDataset:
 
     def sync_snapshots(self, target_dataset, features, show_progress, filter_properties, set_properties,
                        ignore_recv_exit_code, holds, rollback, decrypt, encrypt, also_other_snapshots,
-                       no_send, destroy_incompatible, send_pipes, recv_pipes, zfs_compressed, force):
+                       no_send, destroy_incompatible, send_pipes, recv_pipes, zfs_compressed, force, send_delay):
         """sync this dataset's snapshots to target_dataset, while also thinning
         out old snapshots along the way.
 
@@ -1042,6 +1048,7 @@ class ZfsDataset:
             :type also_other_snapshots: bool
             :type no_send: bool
             :type destroy_incompatible: bool
+            :type send_delay: int
         """
 
         self.verbose("sending to {}".format(target_dataset))
@@ -1110,7 +1117,8 @@ class ZfsDataset:
                                                   ignore_recv_exit_code=ignore_recv_exit_code,
                                                   resume_token=resume_token, write_embedded=write_embedded, raw=raw,
                                                   send_properties=send_properties, send_pipes=send_pipes,
-                                                  recv_pipes=recv_pipes, zfs_compressed=zfs_compressed, force=force)
+                                                  recv_pipes=recv_pipes, zfs_compressed=zfs_compressed, force=force,
+                                                  send_delay=send_delay)
 
                 resume_token = None
 


### PR DESCRIPTION
Kinda surprised no one else has run into this before me, but I recently tried running a backup job to a remote server using [direct TCP transfer](https://github.com/psy0rz/zfs_autobackup/wiki/Performance#direct-tcp-network-transfer) and kept running into a race condition where the send side of the netcat connection would execute before the listen side and the backup job would hang:

```
$ zfs-autobackup -v --ssh-target root@remote.example.com --progress --strip-path=1 --force --send-pipe "nc -v remote.example.com 1234" --recv-pipe "nc -nvlp 1234" aws data
...
  #### Synchronising
  [Source] zfs send custom pipe   : nc -v remote.example.com 1234
  [Target] zfs recv custom pipe   : nc -nvlp 1234
  [Source] hotrod: sending to datad)
  [Source] hotrod/crypt: sending to data/crypt
  [Source] hotrod/crypt/gitlab: sending to data/crypt/gitlab
  [Target] data/crypt/gitlab@aws-20230816111510: receiving incremental
! [Source] STDERR > nc: connect to remote.example.com (X.X.X.X) port 1234 (tcp) failed: Connection refused
! [Target] STDERR > Listening on 0.0.0.0 1234
```

I retried a bunch of times and this would happen _almost_ every time, with the occasional success. I retried with `--debug` and `--dry-run` and saw the command pipeline that got executed:
```
...
# [Target] CMDSKIP> (zfs send --large-block --embed --raw --verbose --parsable --props -i @aws-20230815084358 hotrod/crypt/gitlab@aws-20230816102918 | nc -v remote.example.com 1234) | (ssh
root@remote.example.com 'nc -nvlp 1234 | zfs recv -u -v -F -s data/crypt/gitlab')
...
```

I realized that since I'm using netcat for direct TCP transfer, the pipe from the send commands to the recv commands is superfluous and I could just add a `sleep` before the `zfs send | nc` commands to make sure it didn't start before the netcat listener was ready.

This PR implements the `--send-delay` option, which does just this, and consistently solves the race condition for me with just a 1-second delay:

```
$ zfs-autobackup -v --ssh-target root@remote.example.com --progress --strip-path=1 --force --send-pipe "nc -v remote.example.com 1234" --recv-pipe "nc -nvlp 1234" --send-delay 1 aws data
...
  #### Synchronising
  [Source] zfs send custom pipe   : nc -v remote.example.com 1234
  [Target] zfs recv custom pipe   : nc -nvlp 1234
  [Source] hotrod: sending to datad)
  [Source] hotrod/crypt: sending to data/crypt
  [Source] hotrod/crypt/gitlab: sending to data/crypt/gitlab
  [Source] hotrod/crypt/gitlab@aws-20230816112547: Destroying
  [Target] data/crypt/gitlab@aws-20230816112547: Destroying
  [Target] data/crypt/gitlab@aws-20230816122959: receiving incremental
! [Target] STDERR > Listening on 0.0.0.0 1234
! [Source] STDERR > Connection to remote.example.com (X.X.X.X) 1234 port [tcp/*] succeeded!
! [Target] STDERR > Connection received on X.X.X.X 15081
  [Target] data/crypt/gitlab@aws-20230816123127: receiving incremental
! [Target] STDERR > Listening on 0.0.0.0 1234
! [Source] STDERR > Connection to remote.example.com (X.X.X.X) 1234 port [tcp/*] succeeded!
! [Target] STDERR > Connection received on X.X.X.X 3051
  [Target] data/crypt/gitlab@aws-20230816123226: receiving incremental
! [Target] STDERR > Listening on 0.0.0.0 1234
! [Source] STDERR > Connection to remote.example.com (X.X.X.X) 1234 port [tcp/*] succeeded!
! [Target] STDERR > Connection received on X.X.X.X 33524
...
```
