### PR TITLE
Simple clones support

### DIFF
--- a/tests/test_zfsautobackup_clones.py
+++ b/tests/test_zfsautobackup_clones.py
@@ -1,0 +1,63 @@
+from basetest import *
+
+class TestZfsAutobackupClones(unittest2.TestCase):
+    """clones support"""
+
+    def setUp(self):
+        prepare_zpools()
+        subprocess.check_call("zfs snapshot test_source1/fs1/sub@snap1", shell=True)
+        subprocess.check_call("zfs clone test_source1/fs1/sub@snap1 test_source1/fs1/subclone", shell=True)
+        self.longMessage=True
+
+    def test_clones_never(self):
+        self.assertFalse(ZfsAutobackup(("--no-progress", "--verbose", "--allow-empty", "test", "test_target1")).run())
+        self.assertMultiLineEqual(shelltest("zfs list -H -o name,origin -r " + TEST_POOLS), """
+test_source1\t-
+test_source1/fs1\t-
+test_source1/fs1/sub\t-
+test_source1/fs1/subclone\ttest_source1/fs1/sub@snap1
+test_source2\t-
+test_source2/fs2\t-
+test_source2/fs2/sub\t-
+test_source2/fs3\t-
+test_source2/fs3/sub\t-
+test_target1\t-
+test_target1/test_source1\t-
+test_target1/test_source1/fs1\t-
+test_target1/test_source1/fs1/sub\t-
+test_target1/test_source1/fs1/subclone\t-
+test_target1/test_source2\t-
+test_target1/test_source2/fs2\t-
+test_target1/test_source2/fs2/sub\t-
+""")
+
+    def test_clones_simple(self):
+        # --clones=simple is not enough, you need to transfer the origin snapshot as well!
+        self.assertEqual(1, ZfsAutobackup(("--no-progress", "--verbose", "--allow-empty", "--clones", "simple",
+                                           "test", "test_target1")).run())
+
+    def test_clones_simple_with_other_snapshots(self):
+        # --clones=simple is not enough, you need to transfer the origin snapshot as well!
+        # For example, using --other-snapshots
+        self.assertFalse(ZfsAutobackup(("--no-progress", "--verbose", "--allow-empty", "--clones", "simple", "--other-snapshots",
+                                        "test", "test_target1")).run())
+        self.assertMultiLineEqual(shelltest("zfs list -H -o name,origin -r " + TEST_POOLS), """
+test_source1\t-
+test_source1/fs1\t-
+test_source1/fs1/sub\t-
+test_source1/fs1/subclone\ttest_source1/fs1/sub@snap1
+test_source2\t-
+test_source2/fs2\t-
+test_source2/fs2/sub\t-
+test_source2/fs3\t-
+test_source2/fs3/sub\t-
+test_target1\t-
+test_target1/test_source1\t-
+test_target1/test_source1/fs1\t-
+test_target1/test_source1/fs1/sub\t-
+test_target1/test_source1/fs1/subclone\ttest_target1/test_source1/fs1/sub@snap1
+test_target1/test_source2\t-
+test_target1/test_source2/fs2\t-
+test_target1/test_source2/fs2/sub\t-
+""")
+

--- a/tests/test_zfsnode.py
+++ b/tests/test_zfsnode.py
@@ -173,9 +173,9 @@ test_target1
 
         # basics
         self.assertEqual(s, """[(local): test_source1/fs1,
- (local): test_source1/fs1/onlyparent,
  (local): test_source1/fs1/sub,
- (local): test_source2/fs2/sub]""")
+ (local): test_source2/fs2/sub,
+ (local): test_source1/fs1/onlyparent]""")
 
 
     def test_validcommand(self):

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -110,6 +110,12 @@ class ZfsAutobackup(ZfsAuto):
         group.add_argument('--zfs-compressed', action='store_true',
                            help='Transfer blocks that already have zfs-compression as-is.')
 
+        group.add_argument('--clones', metavar='POLICY', default='never',
+                           choices=('never', 'simple'),
+                           help='Clones support. (The default policy "never" expands clones into full independent datasets. '
+                                '"simple" tries to reproduce the clone when the origin snapshot is already copied '
+                                'in the same target root)')
+
         group = parser.add_argument_group("Data transfer options")
         group.add_argument('--compress', metavar='TYPE', default=None, nargs='?', const='zstd-fast',
                            choices=compressors.choices(),
@@ -399,6 +405,7 @@ class ZfsAutobackup(ZfsAuto):
                                               decrypt=self.args.decrypt, encrypt=self.args.encrypt,
                                               zfs_compressed=self.args.zfs_compressed, force=self.args.force,
                                               guid_check=not self.args.no_guid_check,
+                                              clones=self.args.clones,
                                               make_target_name=lambda source_dataset: self.make_target_name(source_dataset))
             except Exception as e:
 

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -397,7 +397,9 @@ class ZfsAutobackup(ZfsAuto):
                                               destroy_incompatible=self.args.destroy_incompatible,
                                               send_pipes=send_pipes, recv_pipes=recv_pipes,
                                               decrypt=self.args.decrypt, encrypt=self.args.encrypt,
-                                              zfs_compressed=self.args.zfs_compressed, force=self.args.force, guid_check=not self.args.no_guid_check)
+                                              zfs_compressed=self.args.zfs_compressed, force=self.args.force,
+                                              guid_check=not self.args.no_guid_check,
+                                              make_target_name=lambda source_dataset: self.make_target_name(source_dataset))
             except Exception as e:
 
                 fail_count = fail_count + 1


### PR DESCRIPTION
This is #82 rebased against the current master branch, with the following updates:

* Process datasets sorted by `createtxg` instead of `creation` (had also to update a test hardcoding the order).
* Add `--clones never|simple` parameter to keep the old behaviour by default and enable clone support explicitly, keeping the possibility for more options in the future.
* Fix releasing the hold for the origin snapshot on target.
* Don't mention `--other-snapshots` in the missing-origin-on-target message.

Fixes: #36 
Fixes: #284 