### PR TITLE
Update wiki for v4.0

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,24 +25,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github || true
-
-  ubuntu20:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-
-      - name: Prepare
-        run: sudo apt update && sudo apt install zfsutils-linux lzop pigz zstd gzip xz-utils lz4 mbuffer && sudo -H pip3 install coverage unittest2 mock==3.0.5 coveralls
-
-
-      - name: Regression test
-        run: sudo -E ./tests/run_tests
-
-
-      - name: Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: coveralls --service=github || true
-

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ An important feature that's missing from other tools is a reliable `--test` opti
   * Only needs to be installed on one side.
   * Written in python and uses zfs-commands, no special 3rd party dependency's or compiled libraries needed.
   * No annoying config files or properties. 
+* Easy to use in scripts, for example https://github.com/psy0rz/zfs_autobackup/wiki/Example-Proxmox
 
+
+ 
 ## Getting started
 
 Please look at our wiki to [Get started](https://github.com/psy0rz/zfs_autobackup/wiki).

--- a/tests/test_zfsautobackup_clones.py
+++ b/tests/test_zfsautobackup_clones.py
@@ -1,0 +1,63 @@
+from basetest import *
+
+class TestZfsAutobackupClones(unittest2.TestCase):
+    """clones support"""
+
+    def setUp(self):
+        prepare_zpools()
+        subprocess.check_call("zfs snapshot test_source1/fs1/sub@snap1", shell=True)
+        subprocess.check_call("zfs clone test_source1/fs1/sub@snap1 test_source1/fs1/subclone", shell=True)
+        self.longMessage=True
+
+    def test_clones_never(self):
+        self.assertFalse(ZfsAutobackup(("--no-progress", "--verbose", "--allow-empty", "test", "test_target1")).run())
+        self.assertMultiLineEqual(shelltest("zfs list -H -o name,origin -r " + TEST_POOLS), """
+test_source1\t-
+test_source1/fs1\t-
+test_source1/fs1/sub\t-
+test_source1/fs1/subclone\ttest_source1/fs1/sub@snap1
+test_source2\t-
+test_source2/fs2\t-
+test_source2/fs2/sub\t-
+test_source2/fs3\t-
+test_source2/fs3/sub\t-
+test_target1\t-
+test_target1/test_source1\t-
+test_target1/test_source1/fs1\t-
+test_target1/test_source1/fs1/sub\t-
+test_target1/test_source1/fs1/subclone\t-
+test_target1/test_source2\t-
+test_target1/test_source2/fs2\t-
+test_target1/test_source2/fs2/sub\t-
+""")
+
+    def test_clones_simple(self):
+        # --clones=simple is not enough, you need to transfer the origin snapshot as well!
+        self.assertEqual(1, ZfsAutobackup(("--no-progress", "--verbose", "--allow-empty", "--clones", "simple",
+                                           "test", "test_target1")).run())
+
+    def test_clones_simple_with_other_snapshots(self):
+        # --clones=simple is not enough, you need to transfer the origin snapshot as well!
+        # For example, using --other-snapshots
+        self.assertFalse(ZfsAutobackup(("--no-progress", "--verbose", "--allow-empty", "--clones", "simple", "--other-snapshots",
+                                        "test", "test_target1")).run())
+        self.assertMultiLineEqual(shelltest("zfs list -H -o name,origin -r " + TEST_POOLS), """
+test_source1\t-
+test_source1/fs1\t-
+test_source1/fs1/sub\t-
+test_source1/fs1/subclone\ttest_source1/fs1/sub@snap1
+test_source2\t-
+test_source2/fs2\t-
+test_source2/fs2/sub\t-
+test_source2/fs3\t-
+test_source2/fs3/sub\t-
+test_target1\t-
+test_target1/test_source1\t-
+test_target1/test_source1/fs1\t-
+test_target1/test_source1/fs1/sub\t-
+test_target1/test_source1/fs1/subclone\ttest_target1/test_source1/fs1/sub@snap1
+test_target1/test_source2\t-
+test_target1/test_source2/fs2\t-
+test_target1/test_source2/fs2/sub\t-
+""")
+

--- a/tests/test_zfsnode.py
+++ b/tests/test_zfsnode.py
@@ -173,9 +173,9 @@ test_target1
 
         # basics
         self.assertEqual(s, """[(local): test_source1/fs1,
- (local): test_source1/fs1/onlyparent,
  (local): test_source1/fs1/sub,
- (local): test_source2/fs2/sub]""")
+ (local): test_source2/fs2/sub,
+ (local): test_source1/fs1/onlyparent]""")
 
 
     def test_validcommand(self):

--- a/wiki/Backup-to-rsync.net-via-ZFS.md
+++ b/wiki/Backup-to-rsync.net-via-ZFS.md
@@ -1,0 +1,125 @@
+rsync.net has accounts with actual full ZFS support. Note that "A Special "zfs send Capable" Account is Required. (Its basically a VM with full root access)
+
+See https://www.rsync.net/products/zfsintro.html .
+
+This tutorial will show you how to use it.
+
+## Basic backup
+
+We'll start with the basics and then talk about security considerations and encryption.
+
+### Setup ssh keys
+
+To make sure your server can login via ssh automatically:
+
+```console
+[root@pve1 ~]# ssh-copy-id root@xxxxx.rsync.net
+...
+Password for root@xxxxx.rsync.net:
+
+Number of key(s) added: 1
+...
+```
+
+### Find your target
+
+Login to findout the name of the pool you want to use. (rsync.net created it for you)
+
+```console
+[root@pve1 ~]# ssh root@xxxxx.rsync.net
+Last login: Thu Jan 13 23:25:48 2022 from ....
+FreeBSD 12.2-RELEASE-p3 GENERIC 
+
+Welcome to FreeBSD!
+
+...
+root@zh2040b:~ # zfs list
+NAME    USED  AVAIL     REFER  MOUNTPOINT
+data1   480K  1.04T       96K  /mnt/data1
+
+```
+
+So your target could be data1. (or you can create a dataset like data1/pve1 if you like)
+
+### Select filesystems
+
+Select the filesystems that your want to backup:
+
+```console
+[root@pve1 ~]# zfs set autobackup:rsync=true rpool/data/subvol-111-disk-0
+```
+
+### Start actual backup
+
+```console
+[root@pve1 ~]# zfs-autobackup -v --ssh-target root@xxxxx.rsync.net rsyncnet data1
+  zfs-autobackup v3.1.1 - (c)2021 E.H.Eefting (edwin@datux.nl)
+  
+  Selecting dataset property : autobackup:rsyncnet
+  Snapshot format            : rsyncnet-%Y%m%d%H%M%S
+  Hold name                  : zfs_autobackup:rsyncnet
+  
+  #### Source settings
+  [Source] Datasets are local
+  [Source] Keep the last 10 snapshots.
+  [Source] Keep every 1 day, delete after 1 week.
+  [Source] Keep every 1 week, delete after 1 month.
+  [Source] Keep every 1 month, delete after 1 year.
+  
+  #### Selecting
+  [Source] rpool/data/subvol-111-disk-0: Selected
+  
+  #### Snapshotting
+  [Source] Creating snapshots rsyncnet-20220114000822 in pool rpool
+  
+  #### Target settings
+  [Target] Datasets on: root@xxxxx.rsync.net
+  [Target] Keep the last 10 snapshots.
+  [Target] Keep every 1 day, delete after 1 week.
+  [Target] Keep every 1 week, delete after 1 month.
+  [Target] Keep every 1 month, delete after 1 year.
+  [Target] Receive datasets under: data1
+  
+  #### Synchronising
+  [Target] data1/rpool/data: Creating filesystem and parents
+  [Target] data1/rpool/data/subvol-111-disk-0@rsyncnet-20220114000822: receiving full
+>>> Transfer 6% 16MB/s (total 2022MB, 1 minutes left)
+```
+
+## Security considerations
+
+The backup VM is just a dedicated VM with you as the only user.
+
+(Note that these considerations are the same for any cloud provider, not just rsync.net)
+
+### Cloud provider 
+
+Although rsync.net is a very professional and trustworthy company, i still will layout the security implications and how you can mitigate some of them with ZFS encryption:
+
+* The rsync staff can login to your VM to for support reasons, so this means they can easily access your data. Even if you use encryption, as long as the key is loaded on the target they could theoretically access your data.
+* You are of course allowed to deny them access by removing their ssh key. 
+* To make absolutely sure your data is safe without denying anyone access, you should encrypt your data on the source side. (on your server) This will be send over in encrypted form to rsync.net
+* Also look at [How zfs-autobackup handles encryption](Encryption)
+
+
+### Crypto ware
+
+* If you use a push-backup, you are not secured against cryptoware: If they hack your server, they will have access to your rsync.net server as well. 
+* You can actually let the rsync.net server login to your server and pull the backup. 
+* In case of a pull-backup, your attack surface is bigger: Anyone with access to your rsync.net VM could access your server as well. But cryptoware on your server can never access the backups.
+
+
+## Upgrading
+
+When it's time to upgrade to a new FreeBSD version, the staff will contact you and can re-image your machine for you. 
+
+All the data stays intact since its on a seperate disk. 
+
+They will also migrate a few important files like .ssh/authorized_keys
+
+## Conclusion
+
+After 2 years of testing i can say rsync.net is a very good solution for offsite ZFS backups.
+
+
+Note: After i've created this page and did the testing, rsync.net decided to let me keep the account as a way of sponsorship. Thanks :)

--- a/wiki/Clones.md
+++ b/wiki/Clones.md
@@ -1,0 +1,31 @@
+# Replicating ZFS clones
+
+(supported in version 4.0 or higher)
+
+A ZFS clone is a writable copy of a snapshot. Clones are space-efficient: they only store the differences with their origin snapshot. They are used a lot by virtualisation platforms for things like linked-clones and templates.
+
+Older versions of zfs-autobackup would replicate each clone as a full standalone dataset, losing the space-efficiency on the target. Since version 4.0, zfs-autobackup preserves the clone relationship during replication.
+
+## How it works
+
+If a selected source dataset is a clone, and its origin dataset is also selected:
+
+* The origin dataset is always replicated before its clones. (zfs-autobackup sorts the datasets to make sure of this)
+* The origin snapshot is automatically included in the transfer, even if it doesn't match our `--snapshot-format` and you didn't specify `--other-snapshots`. You will see this in the verbose output: `Including as clone origin for a selected clone`
+* The initial transfer of the clone is done as an incremental send from the origin snapshot. This way `zfs recv` reconstructs the clone relationship on the target, and the target stays just as space-efficient as the source.
+
+After the initial transfer, the clone is just synced incrementally like any other dataset.
+
+## When it cant preserve the clone relationship
+
+In some cases zfs-autobackup will warn you and fall back to a full send:
+
+* The origin snapshot is not available on the target. (For example because the origin dataset isn't selected for backup)
+* The origin snapshot on the target has a mismatching GUID.
+* The clone has a "reverse" topology: after a `zfs promote`, the origin of a dataset can live on one of its own children. ZFS can't receive such a stream, so the clone relationship can't be preserved. (You can `zfs promote` the source dataset to flip the lineage back if you want)
+
+A fallback to full send is never a problem for the consistency of your backup, it just uses more space on the target.
+
+## Disabling clone support
+
+Use `--no-clone` if you want the old behaviour: clones will be replicated as full standalone datasets.

--- a/wiki/Common-snapshots-and-holds.md
+++ b/wiki/Common-snapshots-and-holds.md
@@ -1,0 +1,65 @@
+## Common snapshots, bookmarks and holds
+
+If you're new to ZFS these terms can be quite confusing. Whats going on?
+
+**TLDR:** Since version 4.0 zfs-autobackup uses bookmarks on the source side by default. You usually dont have to do or worry about anything.
+
+## Common snapshots
+
+ZFS can do incremental transfers via snapshots. It does this very efficiently by sending over the differences between two snapshots.
+
+There are a few rules for ZFS however:
+
+* The same starting snapshot has to exist on both target and source. So its a common snapshot. (On the source side a bookmark of that snapshot is enough, see below)
+* There cant be any newer snapshots on the target. (Normally should not happen, otherwise use --destroy-incompatible)
+* Encryption has to be compatible (See [[Encryption]])
+
+**If there is no common snapshot or bookmark, the only way to continue is to overwrite the target dataset by running zfs-autobackup with -F.** This resends the whole dataset. (If the target dataset also has snapshots in the way, zfs-autobackup will tell you to use `--destroy-incompatible -F`)
+
+Since version 4.0 zfs-autobackup can also find the common snapshot via an extensive GUID-search: even if the snapshot or bookmark names dont match (because they were created by another tool for example), it can still find and use them. This makes migrating from other tools much easier.
+
+## Bookmarks (version 4.0 and higher)
+
+A ZFS bookmark is a tiny marker that remembers a point-in-time of a dataset. You can use it as the starting point of an incremental `zfs send`, just like a snapshot. The big difference: a bookmark takes up almost no space and doesn't keep any data alive.
+
+After a snapshot is transferred to the target, zfs-autobackup creates a bookmark of it on the source. From that point on the actual source snapshot is allowed to be destroyed: the bookmark is enough to send the next increment.
+
+Advantages over the old holds-method:
+
+* The common snapshot on the source can be destroyed by the [Thinner](Thinner). With `--keep-source=0` almost nothing is kept on the source, saving a lot of space.
+* No more "dataset is busy" frustrations on the source side.
+* You can still safely destroy source snapshots manually.
+
+You can see the bookmarks with `zfs list -t bookmark`. They look like:
+
+```
+rpool/data#offsite1-20260610120000__12345678901234567890
+```
+
+The number after the `__` tag-seperator is the GUID of the target dataset: This way you can send the same backup to multiple targets, and each target gets its own bookmark without interfering with the others.
+
+If the source or target pool doesn't support bookmarks, zfs-autobackup will warn you and automatically fall back to using holds.
+
+Use `--no-bookmarks` if you want the old behaviour with holds on the source. (You can switch back and forth without problems)
+
+## Holds
+
+To prevent accidental deletion of the common snapshot on the **target**, we use "holds". A snapshot that is held cannot be destroyed, until its released with `zfs release`. (Use `zfs holds` to see the holds for a specific snapshot)
+
+zfs-autobackup will automatically hold the common snapshot on the target. It will automatically release it as soon as there is a newer common snapshot.
+
+Before version 4.0 the source side also used holds instead of bookmarks. This could be quite frustrating for new users who tried to delete old datasets that still had holds. (`Dataset is busy`)
+
+Use `--no-holds` if you dont want any holds. In that case its up to you to make sure the common snapshot isn't destroyed.
+
+## Holds, bookmarks and offline backups
+
+Normally when you split up the snapshotting part and backupping part you would do it like this: [[https://github.com/psy0rz/zfs_autobackup/wiki#splitting-up-snapshot-and-backup-job]]
+
+The snapshotter will still connect to the target server and figure out the common snapshot so that they wont be destroyed. It can also cleanup old snapshots from the source if it sees that target doesn't need them (anymore)
+
+However, if you have an offline backup (e.g. a USB disk that you sometimes connect), you are forced to use the snapshot-only tool. You would just run zfs-autobackup without specifying a target dataset or ssh-target. In that case it only makes snapshots and cleans up old snapshots according to the --keep-source schedule.
+
+Since version 4.0 this is much less of a problem: the bookmark of the common snapshot is never destroyed by the thinner, so even with a tight --keep-source schedule the incremental transfer will still work the next time you connect your offline backup.
+
+If you use `--no-bookmarks`, the holds become very important again: in snapshot-only mode zfs-autobackup looks at the holds to see which snapshots are common. Otherwise it might accidentally destroy them if you have a tight --keep-source schedule. So in that case: never use --no-holds.

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -1,0 +1,106 @@
+These are instructions if you want to modify zfs-autobackup, or if you want to run zfs-autobackup directly from git.
+
+## Setting up virtual env
+
+(this is optional, you can also install the requirements globally)
+
+```console
+psy@ws1:~/zfs_autobackup$ python3 -m venv backupdev
+psy@ws1:~/zfs_autobackup$ source backupdev/bin/activate
+(backupdev) psy@ws1:~/zfs_autobackup$ pip install -r requirements.txt 
+psy@ws1 ~/zfs_autobackup % python3 -m venv backupdev                 
+...
+```
+
+## Running zfs_autobackup
+
+To run zfs_autobackup you can just access it as a python module:
+
+```console
+(backupdev) psy@ws1:~/zfs_autobackup$ python -m zfs_autobackup.ZfsAutobackup  --version
+ZfsAutobackup.py v3.2-alpha1 - (c)2021 E.H.Eefting (edwin@datux.nl)
+```
+
+Same goes for zfs-autoverify:
+```console
+(backupdev) psy@ws1:~/zfs_autobackup$ python -m zfs_autobackup.ZfsAutoverify  --version
+ZfsAutoverify.py v3.2-alpha1 - (c)2021 E.H.Eefting (edwin@datux.nl)
+```
+
+## Automated test suites
+
+I'm using a test driven design process, usually i write the code and corresponding tests in unison.
+
+## Running tests via docker
+
+This is the easiest way to run the testsuite against the zfs modules in the running kernel. It will use Alpine for the zfs userspace utilities.
+
+From the main repo just run: `./tests/run_tests_docker`
+
+You can use the unittest -k option to run only specific tests: `./tests/autorun_tests_docker -k test_thinner.TestThinner`
+
+
+## Running directly (without docker)
+
+This can be a bit more tricky.
+
+The tests run against actual zfs commands and create a lot of temporary pools via loopback-images in the /tmp dir. Therefore the tests need root to run.
+
+The tests also need ssh support via root@localhost, so it will create and install a sshkey if needed.
+
+### Running the whole suite
+
+This takes a few minutes and is also done automaticly on each commit via github actions: https://github.com/psy0rz/zfs_autobackup/actions 
+
+```console
+(backupdev) root@ws1:/home/psy/zfs_autobackup# ./tests/run_tests 
+###########################################
+#### Unit testing against:
+#### Python                :3.8.10 (default, Nov 26 2021, 20:14:08)  [GCC 9.3.0]
+#### ZFS userspace         :2.1.1-0york0~20.04
+#### ZFS kernel            :2.1.1-0york0~20.04
+#############################################
+THIS TEST REQUIRES SSH TO LOCALHOST
+test_exitcode (test_cmdpipe.TestCmdPipe)
+test piped exitcodes ... ok
+...
+```
+
+### Running one test
+
+Since running the whole suite takes long, you can run one test like this:
+
+```console
+(backupdev) root@ws1:/home/psy/zfs_autobackup# ./tests/run_test test_verify.py
+###########################################
+#### Unit testing against:
+#### Python                :3.8.10 (default, Nov 26 2021, 20:14:08)  [GCC 9.3.0]
+#### ZFS userspace         :2.1.1-0york0~20.04
+#### ZFS kernel            :2.1.1-0york0~20.04
+#############################################
+test_verify (test_verify.TestZfsEncryption) ... Preparing zfs filesystems...
+```
+
+## Running directly from pycharm
+
+### Method 1, remote via ssh:
+
+This requires pycharm professional, but makes things a lot easier: Tests are just uploaded and runned via ssh on a remote linux server.
+
+This is also nice if you're developing in macos or windows.
+
+Just add an ssh interpreter to a remote server that has zfs support. 
+
+### Method 2, locally:
+
+You need a trick to run all the stuff as root, but still having the advantage of running the tests from the editor.
+
+Just create a venv as you normally would, but then replace the python symlink with a copy of the binary and do this:
+```
+user@host:~/zfs_autobackup/venv/bin$ sudo chown root:root python
+user@host:~/zfs_autobackup/venv/bin$ sudo chmod 4755 python
+```
+
+This has obvious security implications of course, but so far this seems to be the best way to do it. 
+
+

--- a/wiki/Encryption.md
+++ b/wiki/Encryption.md
@@ -1,0 +1,33 @@
+## How does zfs-autobackup handle encryption?
+
+In normal operation, datasets are transferred unaltered:
+
+* Source datasets that are encrypted will be send over as such and stay encrypted at the target side. (In ZFS this is called raw-mode) You dont need keys at the target side if you dont need to access the data. This is especially usefull if you backup to untrusted servers.
+* Source datasets that are plain will stay that way on the target. (Even if the specified target-path IS encrypted.)
+
+Basically you dont have to do anything or worry about anything.
+
+## Decrypting/encrypting
+
+Things get more interesting if you want to change the encryption-state of a dataset during transfer:
+
+* If you want to decrypt encrypted datasets before sending them, you should use the `--decrypt` option. Datasets will then be stored plain at the target.
+* If you want to encrypt plain datasets when they are received, you should use the `--encrypt` option. Datasets will then be stored encrypted at the target. Datasets that are already encrypted will still be sent over unaltered in raw-mode.
+* If you also want re-encrypt encrypted datasets with the target-side encryption you can use both options. 
+
+
+## Notes
+
+* The --encrypt option will rely on inheriting encryption parameters from the parent datasets on the target side. You are responsible for setting those up and loading the keys. So --encrypt is no guarantee for encryption: If you dont set it up, it cant encrypt. (and will store the data unencrypted)
+
+* When using --decrypt, dataset properties will NOT be sent over, due to a bug in ZFS itself: https://github.com/openzfs/zfs/issues/16275 (zfs-autobackup will warn you about this)
+
+* --encrypt will be ignored for datasets that are already encrypted: These are transferred in raw mode, unless you specify --decrypt as well.
+
+* Decide what you want at an early stage: If you change the --encrypt or --decrypt parameter after the inital sync you might get weird and wonderfull errors. (nothing dangerous)
+
+## Some common errors while using zfs encryption
+
+> cannot receive incremental stream: kernel modules must be upgraded to receive this stream.
+
+This happens if you forget to use `--encrypt`, while the target datasets are already encrypted. A very strange error message indeed.

--- a/wiki/Example-Proxmox.md
+++ b/wiki/Example-Proxmox.md
@@ -1,0 +1,85 @@
+## Backup a proxmox cluster with HA replication
+
+We've created a script that will backup all the relevant data of your whole proxmox cluster. (your cluster has to be installed with zfs)
+
+Proxmox can do zfs replication between nodes if you enable it. Because of this, a dataset can exist on multiple nodes, but is only active at one of the nodes. We need to make sure we only backup the active dataset and exclude the rest. This is where the --exclude-unchanged option comes in.
+
+In the example below we have 3 nodes, named pve1, pve2 and pve3.
+
+### Preparing the proxmox nodes
+
+No preparation is needed, the script will take care of everything. You only need to setup the ssh keys, so that the backup server can access the proxmox server.
+
+TIP: make sure your backup server is firewalled and cannot be reached from any production machine.
+
+### SSH config on backup server
+
+I use ~/.ssh/config to specify how to reach the various hosts.
+
+In this example we are making an offsite copy and use portforwarding to reach the proxmox machines:
+```
+Host *
+    ControlPath ~/.ssh/control-master-%r@%h:%p
+    ControlMaster auto
+    ControlPersist 3600
+    Compression yes
+
+Host pve1
+    Hostname some.host.com
+    Port 10001
+
+Host pve2
+    Hostname some.host.com
+    Port 10002
+
+Host pve3
+    Hostname some.host.com
+    Port 10003
+```
+
+### Backup script
+
+I use the following backup script on the backup server.
+
+Adjust the variables HOSTS TARGET and NAME to your needs.
+
+Remember, if you need specific ssh-settings, use ~/.ssh/config. 
+
+```shell
+#!/bin/bash
+
+#v1.1: use  --exclude-unchanged instead of --ignore-replicated
+
+HOSTS="pve1 pve2 pve3"
+TARGET=rpool/pvebackups
+NAME=prox
+
+zfs create -p $TARGET/data &>/dev/null
+for HOST in $HOSTS; do
+
+  echo "################################### RPOOL $HOST"
+
+  # enable backup
+  ssh $HOST "zfs set autobackup:rpool_$NAME=child rpool/ROOT"
+
+  #backup rpool to specific directory per host
+  zfs create -p $TARGET/rpools/$HOST &>/dev/null
+  zfs-autobackup --keep-source=1d1w,1w1m --ssh-source $HOST rpool_$NAME $TARGET/rpools/$HOST --clear-mountpoint --clear-refreservation --ignore-transfer-errors --strip-path 2 --verbose   --no-holds   $@
+
+  zabbix-job-status backup_$HOST""_rpool_$NAME daily $? >/dev/null 2>/dev/null
+
+
+  echo "################################### DATA $HOST"
+
+  # enable backup
+  ssh $HOST "zfs set autobackup:data_$NAME=child rpool/data"
+
+  #backup data filesystems to a common directory
+  zfs-autobackup --keep-source=1d1w,1w1m --ssh-source $HOST data_$NAME $TARGET/data --clear-mountpoint --clear-refreservation --ignore-transfer-errors --strip-path 2 --verbose   --exclude-unchanged 300000 --no-holds   $@
+
+  zabbix-job-status backup_$HOST""_data_$NAME daily $? >/dev/null 2>/dev/null
+
+done
+```
+
+This script will also send the backup status to Zabbix. (if you've installed my zabbix-job-status script https://github.com/psy0rz/stuff/tree/master/zabbix-jobs)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,368 @@
+Look at the [README.md](../blob/master/README.md) for the introduction.
+
+# Getting started
+
+## Installation
+
+zfs-autobackup creates ZFS snapshots on a "source" machine and then replicates those snapshots to a "target" machine via SSH.
+
+zfs-autobackup may be installed on either the source machine or the target machine, installing it on both is unnecessary.
+
+When installed on the source, zfs-autobackup will push snapshots to the target.  When installed on the target, zfs-autobackup will pull snapshots from the source.
+
+### Using pip
+
+The recommended installation method on most machines is to use [pip](https://pypi.org/project/zfs-autobackup/):
+
+```console
+[root@server ~]# pip install --upgrade zfs-autobackup
+```
+
+The above command can also be used to upgrade zfs-autobackup to the newest stable version.
+
+To install the latest beta version add the `--pre` option.
+
+### Using pipx
+
+For more modern distributions it might be best to use pipx:
+```console
+[root@server ~]# pipx install zfs-autobackup
+```
+
+To install the latest beta version add `--pip-args=--pre` option.
+
+### Using easy_install
+
+On older machines you might have to use easy_install:
+
+```console
+[root@server ~]# easy_install zfs-autobackup
+```
+
+### Using the sources
+
+If you don't want to install zfs-autobackup, or want to make some changes to the code, look at [Development](Development)
+
+## Example
+
+In this example, a machine called `backup` is going to create and pull backup snapshots from a machine called `pve01`.
+
+### Setup SSH login
+
+As zfs-autobackup will perform numerous remote commands via ssh, we strongly recommend setting up passwordless login via ssh. This means generating an ssh key on target machine (`backup`) and copying the public ssh key to the source machine (`pve01`).
+
+NOTE: Most examples use root-access on both the source and target. If you want to use a normal user, look [here](https://github.com/psy0rz/zfs_autobackup/wiki/Manual#running-without-root)
+
+#### Generate an SSH key on `backup`
+
+Create an SSH key on the backup machine that runs zfs-autobackup. You only need to do this once.
+
+Use the `ssh-keygen` command and leave the passphrase empty:
+
+```console
+root@backup:~# ssh-keygen
+Generating public/private rsa key pair.
+Enter file in which to save the key (/root/.ssh/id_rsa):
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+...
+root@backup:~#
+```
+
+#### Copy the SSH key to `pve01`
+
+Now you need to copy the public part of the key to `pve01`
+
+The `ssh-copy-id` command is a handy tool to automate this. It will just ask for your password.
+
+```console
+root@backup:~# ssh-copy-id root@pve01
+/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/.ssh/id_rsa.pub"
+/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
+Password:
+
+Number of key(s) added: 1
+
+root@backup:~#
+```
+This allows the backup machine to login to `pve01` as root without password.
+
+### Select filesystems to backup
+
+Next, we specify the filesystems we want to snapshot and replicate by assigning a unique group name to those filesystems.
+
+It's important to choose a unique group name and to use the name consistently.  (Advanced tip: If you have multiple sets of filesystems that you wish to backup differently, you may do this by creating multiple group names.)
+
+In this example, we assign the group name `offsite1` to the filesystems we want to backup.
+
+On the source machine, we set the ```autobackup:offsite1``` zfs property to ```true```, as follows:
+
+```console
+[root@pve01 ~]# zfs set autobackup:offsite1=true rpool
+[root@pve01 ~]# zfs get -t filesystem,volume autobackup:offsite1
+NAME                      PROPERTY             VALUE                SOURCE
+rpool                     autobackup:offsite1  true                 local
+rpool/ROOT                autobackup:offsite1  true                 inherited from rpool
+rpool/ROOT/pve-1          autobackup:offsite1  true                 inherited from rpool
+rpool/data                autobackup:offsite1  true                 inherited from rpool
+rpool/data/vm-100-disk-0  autobackup:offsite1  true                 inherited from rpool
+rpool/data/vm-101-disk-0  autobackup:offsite1  true                 inherited from rpool
+rpool/tmp                 autobackup:offsite1  true                 inherited from rpool
+```
+
+ZFS properties are ```inherited``` by child datasets. Since we've set the property on the highest dataset, we're essentially backing up the whole pool.
+
+If we don't want to backup everything, we can exclude certain filesystem by setting the property to ```false```:
+
+```console
+[root@pve01 ~]# zfs set autobackup:offsite1=false rpool/tmp
+[root@pve01 ~]# zfs get -t filesystem,volume autobackup:offsite1
+NAME                      PROPERTY             VALUE                SOURCE
+rpool                     autobackup:offsite1  true                 local
+rpool/ROOT                autobackup:offsite1  true                 inherited from rpool
+rpool/ROOT/pve-1          autobackup:offsite1  true                 inherited from rpool
+rpool/data                autobackup:offsite1  true                 inherited from rpool
+rpool/data/vm-100-disk-0  autobackup:offsite1  true                 inherited from rpool
+rpool/data/vm-101-disk-0  autobackup:offsite1  true                 inherited from rpool
+rpool/tmp                 autobackup:offsite1  false                local
+```
+
+The ```autobackup``` property can have these values:
+ * ```true```: Backup the dataset and all its children.
+ * ```false```: Don't backup the dataset and all its children. (Exclude the dataset)
+ * ```child```: Only backup the children of the dataset, not the dataset itself. 
+ * ```parent```: Only backup the dataset, but not the children. (supported in version 3.2 or higher)
+
+(Note: Only use the ```zfs``` command to set these properties.  Do not use the ```zpool``` command.)
+
+To **remove** the property completely, use:
+```console
+zfs inherit autobackup:offsite1 rpool
+```
+
+### Running zfs-autobackup
+
+Run the script on the backup machine and pull the data from the source machine specified by ```--ssh-source```.
+
+```console
+[root@backup ~]# zfs-autobackup -v --clear-mountpoint --ssh-source pve01 offsite1 data/backup/pve01
+  zfs-autobackup v3.1.1 - (c)2021 E.H.Eefting (edwin@datux.nl)
+  
+  Selecting dataset property : autobackup:offsite1
+  Snapshot format            : offsite1-%Y%m%d%H%M%S
+  Hold name                  : zfs_autobackup:offsite1
+  
+  #### Source settings
+  [Source] Datasets on: pve01
+  [Source] Keep the last 10 snapshots.
+  [Source] Keep every 1 day, delete after 1 week.
+  [Source] Keep every 1 week, delete after 1 month.
+  [Source] Keep every 1 month, delete after 1 year.
+  
+  #### Selecting
+  [Source] rpool: Selected
+  [Source] rpool/ROOT: Selected
+  [Source] rpool/ROOT/pve-1: Selected
+  [Source] rpool/data: Selected
+  [Source] rpool/data/vm-100-disk-0: Selected
+  [Source] rpool/data/vm-101-disk-0: Selected
+  [Source] rpool/tmp: Excluded
+  
+  #### Snapshotting
+  [Source] Creating snapshots offsite1-20220107131107 in pool rpool
+  
+  #### Target settings
+  [Target] Datasets are local
+  [Target] Keep the last 10 snapshots.
+  [Target] Keep every 1 day, delete after 1 week.
+  [Target] Keep every 1 week, delete after 1 month.
+  [Target] Keep every 1 month, delete after 1 year.
+  [Target] Receive datasets under: data/backup/pve01
+  
+  #### Synchronising
+  [Target] data/backup/pve01/rpool@offsite1-20220107131107: receiving full
+  [Target] data/backup/pve01/rpool/ROOT@offsite1-20220107131107: receiving full
+  [Target] data/backup/pve01/rpool/ROOT/pve-1@offsite1-20220107131107: receiving full
+  [Target] data/backup/pve01/rpool/data@offsite1-20220107131107: receiving full
+  [Target] data/backup/pve01/rpool/data/vm-100-disk-0@offsite1-20220107131107: receiving full
+  [Target] data/backup/pve01/rpool/data/vm-101-disk-0@offsite1-20220107131107: receiving full
+  
+  #### All operations completed successfully
+```
+
+### The results
+
+As you might notice, zfs-autobackup preserves the whole parent path of the source.
+
+So `rpool/data/vm100-disk-0` ends up as: `data/backup/pve01/rpool/data/vm-100-disk-0`
+
+Since it's a backup, it's useful to preserve the original structure of the data like this.
+
+### Stripping the path
+
+Since you might think this is ugly, there is the `--strip-path` option. However this can lead to collisions if two source datasets result in the same target paths. Since version 3.1.2 zfs-autobackup will check for this and emit an error.
+
+#### Making source and target paths look the same
+
+If you want your source and target structure to look exactly the same, you have to do the following:
+
+* Select the whole source-pool. In this case: `zfs set autobackup:offsite1=true rpool`
+* Use `--strip-path=1`
+* Specify target-pool as target-path. In this case: `data`
+* You may need to use `--force` option the first time to overwrite the existing target pool.  It is recommended you try with `--test` and without `--force` first (New in v3.1.2).
+
+This configuration will attempt replicate the entire pool from the source to the target. If you wish to exclude specific datasets from being replicated from the source pool, make sure that you do so by running commands such as:
+
+```console
+[root@pve01 ~]# zfs set autobackup:offsite1=false rpool/tmp
+```
+
+For each dataset you don't want to replicate BEFORE you run zfs-autobackup without `--test` for the first time.
+
+### Pull or push?
+
+Note that this is called a "pull" backup.  The backup (target) machine pulls the backup from the source machine. This is usually the preferred way.
+
+It is also possible to let a source machine push its backup to the target machine. There are security implications to both approaches, as follows:
+
+* With a pull backup, the target machine will have ssh access to the source machine.
+* With a push backup, the source machine will have ssh access to the target machine.
+
+If you wish to do a push backup, then you would setup the SSH keys the other way around and use the `--ssh-target` parameter on the source machine.
+
+Note that you can always change the ssh source and target parameters at a later point without any problems.
+
+#### Pull+push (zero trust)
+
+It also possible to use a third server that pulls backups from the source and pushes the data to the target server via one stream. This way the source and target server won't have to be able to reach each other. If one server gets hacked, they can't access the other server.
+
+To do this, you only have to install zfs-autobackup on a third server and use both `--ssh-source` and `--ssh-target` to specify the other source and target servers.
+
+## Local Usage
+
+It is also possible to run zfs-autobackup locally, where you could backup snapshots to a different pool on the same server. This is done by simply omitting the `--ssh-source` and `--ssh-target` parameters. 
+
+For example, let's say you have an additional pool for local backups called `backups`, that's on separate device(s) from your data pools. In this pool, you have a dataset called `autobackup`. You could run the following command (assuming you set the zfs group name to `autobackup:local` on your data filesystems):
+
+> zfs-autobackup -v local backups/autobackup
+
+Combining this with a remote push or pull backup, you could then set the zfs group name on your backup filesystems to something like `autobackup:remote`, then have a second zfs-autobackup job that backs up these snapshots to your remote storage like:
+
+> zfs-autobackup -v --ssh-target root@backupserver remote data/backup/pve01
+
+## Automatic backups
+
+Now every time you run the command, zfs-autobackup will create a new snapshot and replicate your data.
+
+Older snapshots will eventually be deleted, depending on the `--keep-source` and `--keep-target` settings. The defaults are shown above under the 'Settings summary'. Look at [Thinner](Thinner) for more info.
+
+Once you've got the correct settings for your situation, you can just store the command in a cronjob or just create a script and run it manually when you need it.
+
+### Avoid parallel jobs
+
+If a cronjob takes too long, it might start the next zfs-autobackup job, while the previous one hasn't finished. This won't break anything permanently, but backups might fail and the IO load might get even higher. If the jobs keep compounding it might lead to memory exhaustion and server crashes.
+
+Some cron daemons prevent parallel jobs automatically, but you might have to use flock to prevent this. For example:
+```
+22 * * * * flock -n /var/backups.lock zfs-autobackup backup1 rpool/backup -v --ssh-target=....
+```
+
+If you do this, you might miss snapshots of course. If you want to prevent this, split it up in a snapshot-only job (by omitting the target path) and a send-only job that has the --no-snapshot parameter.
+
+
+## Splitting up snapshot and backup jobs
+
+You might want to make snapshots during the week, and only transfer data during the weekends.
+
+In this case you would run this each weekday: 
+
+> zfs-autobackup -v --ssh-source pve01 offsite1 data/backup/pve01 --no-send
+
+And this on weekend days:
+
+> zfs-autobackup -v --ssh-source pve01 offsite1 data/backup/pve01
+
+You can also create the snapshots in offline mode by using zfs-autobackup as a snapshot tool on the source side. This way the snapshots will always be created, even if the backup server is offline or unreachable.
+
+## Use as a snapshot tool
+
+You can use zfs-autobackup as a standalone snapshot tool.
+
+To do this, simply omit the target-path, as follows:
+
+> zfs-autobackup -v --ssh-source pve01 offsite1
+
+Only use this if you don't want to make any backup at all, or if a target isn't reachable during the snapshotting phase.
+
+If you have offline backups, checkout [[Common-snapshots-and-holds]]
+
+## Monitoring
+
+Don't forget to monitor the results of your backups, look at [Monitoring](Monitoring) for more info.
+
+## Use alongside other snapshot tools
+
+zfs-autobackup can happily co-exist on the same system as other ZFS snapshot tools such as zfs-auto-snapshot if you are already using one. zfs-autobackup will not thin any manually created snapshots or those created by other snapshot tools, it will only thin its own shapshots if you use its `--keep-source` or `--keep-target` options.
+
+## Specifying ssh port or options
+
+The correct way to do this is by creating ~/.ssh/config:
+
+```console
+Host smartos04
+    Hostname 1.2.3.4
+    Port 1234
+    user root
+```
+
+This way you can just specify "smartos04" as host.
+
+Look in ```man ssh_config``` for many more options.
+
+## Multiple backups of the same data
+
+You can use multiple zfs-autobackup jobs to transfer data to multiple targets. Just make sure that you use different backup names. This way the jobs should not interfere with each other: Each job only removes its own snapshots.
+
+### Using the same backup name
+
+You CAN use the same backup name to transfer data to multiple targets. However in that case it's up to you to make sure that a common snapshot of one backup job isn't deleted by the other job.
+
+One way to do this is to make adjust the --keep-source option or to make sure the backups run at a close enough interval.
+
+To prevent confusion, and to be more flexible, I would advise you to always use easily distinguished names e.g.: autobackup:offsite and autobackup:local, for example.
+
+## Tips
+
+* Use ```--clear-mountpoint``` to prevent all kinds of problems. See [[Mounting]]
+* Use ```--debug``` if something goes wrong and you want to see the commands that are executed. This will also stop at the first error.
+* Use these only one time if needed: `--force` `--destroy-incompatible` `--rollback`. Don't add them to your script. Try to solve the underlying cause if you keep needing them.
+* Set the ```readonly``` property of the target filesystem to ```on```. This prevents changes on the target side. (Due to the nature of ZFS itself, if any changes are made to a dataset on the target machine, then the next backup to that target machine will probably fail. Such a failure can probably be resolved by perfroming a target-side zfs rollback of the affected dataset.) Note that ```readonly``` prevents changes to the CONTENTS of the dataset directly. It's still possible to receive new datasets and manipulate properties etc.
+* Use ```--clear-refreservation``` to save space on your backup machine.
+* zfs-autobackup holds the common snapshot on the target by default, so you might get "dataset busy" if you try to destroy a snapshot there. (check zfs holds --help or see [here.](https://github.com/psy0rz/zfs_autobackup/wiki/Problems#dataset-is-busy)) On the source side it uses bookmarks since version 4.0, see [[Common-snapshots-and-holds]]
+
+## Restore example
+
+Restoring can be done with simple zfs commands. For example:
+
+```console
+root@fs1:/home/psy#  zfs send fs1/zones/backup/zfsbackups/server01/vm01@offset1-20220110230003 | ssh root@2.2.2.2 "zfs recv rpool/restore"
+```
+
+## More information
+
+Continue reading the [Full manual](Manual). It will explain in more detail how zfs-autobackup works.
+
+Or jump to:
+
+* [Upgrading to v4.0](Upgrading-to-v4.0)
+* [Performance tips (recommended)](Performance)
+* [Common problems and errors](Problems)
+* [Thinning out obsolete snapshots](Thinner)
+* [Replicating ZFS clones](Clones)
+* [Handling ZFS encryption](Encryption)
+* [Transfer buffering, compression and rate limiting.](Piping)
+* [Custom Pre- and post-snapshot commands](PrePost)
+* [Monitoring](Monitoring)
+* [Proxmox Example](Example%20Proxmox.md)
+
+If you like Alpine linux and want to use it with ZFS, checkout my other project: https://github.com/psy0rz/alpinebox

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -1,0 +1,416 @@
+
+## Reference manual
+
+If you're new to zfs-autobackup you should read the [Getting started](Home) page first. It shows you how to get things done.
+
+Then read this full manual to understand how zfs-autobackup works, and what all the options are doing. 
+
+Both guides are complementary.
+
+### Usage
+
+```
+usage: ZfsAutobackup.py [--help] [--test] [--verbose] [--debug]
+                        [--debug-output] [--progress] [--utc] [--version]
+                        [--ssh-config CONFIG-FILE] [--ssh-source USER@HOST]
+                        [--ssh-target USER@HOST] [--property-format FORMAT]
+                        [--snapshot-format FORMAT] [--hold-format FORMAT]
+                        [--strip-path N] [--tag-seperator STRING] [--tag TAG]
+                        [--exclude-unchanged BYTES]
+                        [--exclude-snapshot-pattern EXCLUDE_SNAPSHOT_PATTERN]
+                        [--no-snapshot] [--pre-snapshot-cmd COMMAND]
+                        [--post-snapshot-cmd COMMAND] [--min-change BYTES]
+                        [--allow-empty] [--other-snapshots]
+                        [--set-snapshot-properties PROPERTY=VALUE,...]
+                        [--no-guid-check] [--no-send] [--no-holds]
+                        [--no-bookmarks] [--no-clone] [--clear-refreservation]
+                        [--clear-mountpoint]
+                        [--filter-properties PROPERTY,...]
+                        [--set-properties PROPERTY=VALUE,...] [--rollback]
+                        [--force] [--destroy-incompatible]
+                        [--ignore-transfer-errors] [--decrypt] [--encrypt]
+                        [--zfs-compressed] [--compress [TYPE]]
+                        [--rate DATARATE] [--buffer SIZE]
+                        [--buffer-chunk-size BUFFERCHUNKSIZE]
+                        [--send-pipe COMMAND] [--recv-pipe COMMAND]
+                        [--no-thinning] [--keep-source SCHEDULE]
+                        [--keep-target SCHEDULE] [--destroy-missing SCHEDULE]
+                        [BACKUP-NAME] [TARGET-PATH]
+
+ZfsAutobackup.py v4.0-beta3 - (c)2026 E.H.Eefting (edwin@datux.nl)
+
+positional arguments:
+  BACKUP-NAME           Name of the backup to select
+  TARGET-PATH           Target ZFS filesystem (optional)
+
+Common options:
+  --help, -h            show help
+  --test, --dry-run, -n
+                        Dry run, dont change anything, just show what would be
+                        done (still does all read-only operations)
+  --verbose, -v         verbose output
+  --debug, -d           Show zfs commands that are executed, stops after an
+                        exception.
+  --debug-output        Show zfs commands and their output/exit codes. (noisy)
+  --progress            show zfs progress output. Enabled automaticly on ttys.
+                        (use --no-progress to disable)
+  --utc                 Use UTC instead of local time when dealing with
+                        timestamps for both formatting and parsing. To
+                        snapshot in an ISO 8601 compliant time format you may
+                        for example specify --snapshot-format
+                        "{}-%Y-%m-%dT%H:%M:%SZ". Changing this parameter
+                        after-the-fact (existing snapshots) will cause their
+                        timestamps to be interpreted as a different time than
+                        before.
+  --version             Show version.
+
+SSH options:
+  --ssh-config CONFIG-FILE
+                        Custom ssh client config
+  --ssh-source USER@HOST
+                        Source host to pull backup from.
+  --ssh-target USER@HOST
+                        Target host to push backup to.
+
+String formatting options:
+  --property-format FORMAT
+                        Name of the ZFS user-property used to select datasets
+                        for this backup. The literal "{}" is substituted with
+                        BACKUP-NAME. Default: autobackup:{}
+  --snapshot-format FORMAT
+                        Format of the snapshot-name part after the "@". The
+                        literal "{}" is substituted with BACKUP-NAME, then
+                        strftime-codes (e.g. %Y %m %d %H %M %S) are expanded
+                        against the current time. Must not contain the tag-
+                        seperator. Default: {}-%Y%m%d%H%M%S
+  --hold-format FORMAT  Name of the zfs-hold placed on snapshots to prevent
+                        accidental deletion. The literal "{}" is substituted
+                        with BACKUP-NAME. Default: zfs_autobackup:{}
+  --strip-path N        Number of directories to strip from target path.
+  --tag-seperator STRING
+                        Tag seperator for snapshots and bookmarks. Default: __
+  --tag TAG             Backup tag to add to snapshots names. (For
+                        administrative purposes)
+
+Selection options:
+  --exclude-unchanged BYTES
+                        Exclude datasets that have less than BYTES data
+                        changed since any last snapshot. (Use with proxmox HA
+                        replication)
+  --exclude-snapshot-pattern EXCLUDE_SNAPSHOT_PATTERN
+                        Regular expression to match snapshots that will be
+                        ignored.
+
+Snapshot options:
+  --no-snapshot         Don't create new snapshots (useful for finishing
+                        uncompleted backups, or cleanups)
+  --pre-snapshot-cmd COMMAND
+                        Run COMMAND before snapshotting (can be used multiple
+                        times.
+  --post-snapshot-cmd COMMAND
+                        Run COMMAND after snapshotting (can be used multiple
+                        times.
+  --min-change BYTES    Only create snapshot if enough bytes are changed.
+                        (default 1)
+  --allow-empty         If nothing has changed, still create empty snapshots.
+                        (Same as --min-change=0)
+  --other-snapshots     Send over other snapshots as well, not just the ones
+                        created by this tool.
+  --set-snapshot-properties PROPERTY=VALUE,...
+                        List of properties to set on the snapshot.
+  --no-guid-check       Dont check guid of common snapshots. (faster)
+
+Transfer options:
+  --no-send             Don't transfer snapshots (useful for cleanups, or if
+                        you want a separate send-cronjob)
+  --no-holds            Don't hold snapshots. (Faster. Allows you to destroy
+                        common snapshot.)
+  --no-bookmarks        Don't use bookmarks.
+  --no-clone            Don't preserve clone relationships during replication.
+                        Source datasets that are clones will be replicated as
+                        full standalone datasets.
+  --clear-refreservation
+                        Filter "refreservation" property. (recommended, saves
+                        space. same as --filter-properties refreservation)
+  --clear-mountpoint    Set property canmount=noauto for new datasets.
+                        (recommended, prevents mount conflicts. same as --set-
+                        properties canmount=noauto)
+  --filter-properties PROPERTY,...
+                        List of properties to "filter" when receiving
+                        filesystems. (you can still restore them with zfs
+                        inherit -S)
+  --set-properties PROPERTY=VALUE,...
+                        List of propererties to override when receiving
+                        filesystems. (you can still restore them with zfs
+                        inherit -S)
+  --rollback            Rollback changes to the latest target snapshot before
+                        starting. (normally you can prevent changes by setting
+                        the readonly property on the target_path to on)
+  --force, -F           Use zfs -F option to force overwrite/rollback. (Useful
+                        with --strip-path=1, but use with care)
+  --destroy-incompatible
+                        Destroy incompatible snapshots on target. Use with
+                        care! (also does rollback of dataset)
+  --ignore-transfer-errors
+                        Ignore transfer errors (still checks if received
+                        filesystem exists. useful for acltype errors)
+  --decrypt             Decrypt data before sending it over.
+  --encrypt             Encrypt data after receiving it.
+  --zfs-compressed      Transfer blocks that already have zfs-compression as-
+                        is.
+
+Data transfer options:
+  --compress [TYPE]     Use compression during transfer, defaults to zstd-fast
+                        if TYPE is not specified. (gzip, pigz-fast, pigz-slow,
+                        zstd-fast, zstd-slow, zstd-adapt, xz, lzo, lz4)
+  --rate DATARATE       Limit data transfer rate in Bytes/sec (e.g. 128K.
+                        requires mbuffer.)
+  --buffer SIZE         Add zfs send and recv buffers to smooth out IO bursts.
+                        (e.g. 128M. requires mbuffer)
+  --buffer-chunk-size BUFFERCHUNKSIZE
+                        Tune chunk size when mbuffer is used. (requires
+                        mbuffer.)
+  --send-pipe COMMAND   pipe zfs send output through COMMAND (can be used
+                        multiple times)
+  --recv-pipe COMMAND   pipe zfs recv input through COMMAND (can be used
+                        multiple times)
+
+Thinner options:
+  --no-thinning         Do not destroy any snapshots.
+  --keep-source SCHEDULE
+                        Thinning schedule for old source snapshots. Default:
+                        10,1d1w,1w1m,1m1y
+  --keep-target SCHEDULE
+                        Thinning schedule for old target snapshots. Default:
+                        10,1d1w,1w1m,1m1y
+  --destroy-missing SCHEDULE
+                        Destroy datasets on target that are missing on the
+                        source. Specify the time since the last snapshot, e.g:
+                        --destroy-missing 30d
+
+Full manual at: https://github.com/psy0rz/zfs_autobackup
+```
+
+## Safe defaults
+
+zfs-autobackup uses safe defaults such as:
+
+* Preserving all dataset properties.  This can have its drawbacks to, for example [Mounting](Mounting)
+* Preserving full dataset paths. Look [here](Home#stripping-the-path) how to change that.
+* Only modify snapshots that match the zfs-autobackup format.
+* Not rolling back or forcing anything.
+* Checking everything, failing early and in a verbose manner.
+* Don't do anything unexpected.
+
+Keeping this in mind can help make more sense of the options described here: most of the options are to modify these safe defaults.
+
+### Good for scripting: No config files 
+
+zfs-autobackup has no config files on purpuse, this makes it very suitable to use in scripts if you have more complex setups.
+
+For example, see: https://github.com/psy0rz/zfs_autobackup/wiki/Example-Proxmox
+
+So keep this in mind in case you're wondering why zfs-autobackup does it like this. 
+
+## Common options
+
+You probably already know these from the Getting started guide, scroll on to Step 1 in that case.
+
+### Testing and debugging
+
+It's recommended to always use `--verbose` or `-v` to see whats going on. It makes debugging easier.
+
+During initial setup and testing of a backup you should use `--test`. This will perform all the read-only operations, but will not change anything. It will show you exactly what it's going to do.
+
+If you encounter a problem and want to see the exact ZFS commands, use `--debug`. This outputs all the underlying zfs-commands in a different color. To see the output of each command, use `--debug-output`.
+
+Note that debug mode will abort on the first failed dataset, and show a stacktrace so it's not recommended for use in production.
+
+### SSH source and target options
+
+zfs-autobackup can be used locally or remotely via ssh.
+
+These options are for backing up to or from remote hosts via ssh:
+
+  * `--ssh-source USER@HOST`: Source host to pull backup from.
+  * `--ssh-target USER@HOST`: Target host to push backup to.
+
+If you dont specify a source or target host, zfs-autobackup will operate locally.
+
+Things like different ssh-ports should be configured in your `~/.ssh/config file`. (Or the one specified with `--ssh-config CONFIG-FILE`)
+
+# Backup procedure
+
+zfs-autobackup always performs its operations in a certain order.
+
+All these steps are described here:
+
+## Step 1: Selecting
+
+This step selects the datasets that are part of the run.
+
+### Dataset property
+
+Selection is done by a dataset property. The name of this property is the `backup-name`, formatted by `--property-format`. The default is `autobackup:backup-name`.
+
+The zfs-autobackup property can have the following values:
+
+* `true`: Select the dataset and all its children.
+* `false`: Exclude the dataset and all its children.
+* `child`: Only select the children of the dataset, not the dataset itself.
+* `parent`: Only select the parent, but not the children. (supported in version 3.2 or higher)
+
+If there are no datasets that have this property set then zfs-autobackup exits with an error.
+
+### Further exclusions
+
+Datasets can also be excluded from selection by these options:
+
+* `--exclude-unchanged BYTES`: Exclude datasets that have less than BYTES data changed since the last snapshot. (Use with proxmox HA replication)
+
+NOTE: The `--exclude-received` option is removed in version 4.0: zfs-autobackup now always filters all `autobackup:...` properties when receiving datasets, so recursive replication between backup partners can't happen anymore. To get rid of existing properties on the target do this one time: `zfs inherit -r autobackup:backup1 pool/backup1`
+
+## Step 2: Snapshotting
+
+In this step a snapshot is created on the datasets selected in step 1.
+
+zfs-autobackup creates atomic snapshots per pool. This is a single `zfs snapshot` command that includes all the snapshots that need to be taken for that pool.
+
+Snapshotting can be skipped with `--no-snapshot`. Using this option will result in only syncing existing snapshots.
+
+### Snapshot format
+
+Snapshots are created using a specific naming format. This includes a timestamp that zfs-autobackup uses to determine when a snapshot can be destroyed by the [Thinner](Thinner).
+
+It is possible to change this format by using `--snapshot-format`. Other snapshots that do not match this format are normally ignored by zfs-autobackup. Use `--utc` to use UTC for timestamps.
+
+We use python datetime formatting, a table is on the end at this page: https://www.w3schools.com/python/python_datetime.asp
+
+### Tags
+
+(supported in version 4.0 or higher)
+
+With `--tag` you can add an administrative tag to the snapshot names. For example `--tag offsite1` results in snapshot names like `backup1-20260610120000__offsite1`.
+
+Tags are purely for your own administrative purposes: zfs-autobackup ignores the tag-part when matching and thinning snapshots. This way you can see which job created a snapshot, while jobs with different tags still use each others snapshots as common snapshot.
+
+The tag is separated from the timestamp by the `--tag-seperator`, which defaults to `__`. (According to `man 8 zfs` the allowed characters are `_.: -`)
+
+You can also ignore certain snapshots completely with `--exclude-snapshot-pattern`, which takes a regular expression. Excluded snapshots will not be transferred or destroyed.
+
+### Pre- and post snapshot commands
+
+You can run commands pre- and post-snapshotting with `--pre-snapshot-cmd` and `--post-snapshot-cmd.`
+
+More info [here](PrePost).
+
+
+### Skipping conditions
+
+Snapshot creation will be skipped for datasets that have no changes since the last snapshot.
+
+This can be controlled by:
+* `--min-change BYTES`: Only create snapshot if enough bytes have changed. (default 1)
+* `--allow-empty`: If nothing has changed, still create empty snapshots. (Same as --min-change=0)
+
+### Other options
+
+* `--set-snapshot-properties PROPERTY=VALUE,...`: List of properties to set on the new snapshot.
+
+## Step 3: Synchronising
+
+Syncronisation is done only if `TARGET-PATH` is specified. Otherwise zfs-autobackup is just a snapshot tool and stops after step 2.
+
+For each selected source dataset it does the following steps:
+
+### Step 3.1: Planning
+
+If the target dataset already exists:
+* We determine the [Common snapshot or bookmark](Common-snapshots-and-holds). Bookmarks are preferred over snapshots. If name-matching fails, we also do an extensive GUID-search, so we can even sync from snapshots or bookmarks that were created by other tools.
+* We check the GUID of the common snaphot, unless `--no-guid-check` is set.
+* We determine a list of incompatible snapshots that are in the way. (after our common snapshot)
+* If there isn't a valid common snapshot or bookmark, the dataset fails with instructions on how to continue. (Use `-F` to overwrite the target dataset, or `--destroy-incompatible -F` if it also has snapshots)
+
+If the source dataset is a ZFS clone, we will try to preserve the clone relationship on the target. See [Clones](Clones).
+
+We determine which snapshots are kept and which ones can be destroyed by the [Thinner](Thinner). Note that only our own snapshots (matching the `--snapshot-format`), are considered for deletion.
+
+If `--no-thinning` is used, this list of obsolete snapshots will always be empty.
+
+### Step 3.2: Pre-clean
+
+After planning, provided `--no-thinning` isn't used, we destroy obsolete snapshots on the source and target to save space during sync.
+
+### Step 3.3: Destroy incompatible snapshots
+
+If the planner has detected incompatible snapshots, we will destroy them. But since this can be dangerous and is normally not needed, you have to enable this with `--destroy-incompatible`
+
+Otherwise the dataset will fail.
+
+### Step 3.4: Transferring snapshots
+
+Now the snapshots are actually transferred, unless `--no-send` is used.
+
+If `--other-snapshots` is specified, we will also transfer snapshots that do not match our `--snapshot-format`. These other snapshots will never be destroyed.
+
+For each snapshot we:
+* Check if we need to resume an aborted transfer.
+* Handle [Encryption](Encryption) options. (`--encrypt` and `--decrypt`)
+* Transfer the data, using various [Transfer options](Piping) (`--zfs-compressed`, `--compress`, `--send-pipe`, `--recv-pipe`, `--buffer`, `--rate`)
+* Filter/set properties according to `--set-properties` and `--filter-properties`. Properties starting with `autobackup:` are always filtered.
+* Create a [bookmark](Common-snapshots-and-holds) of the new common snapshot on the source, and hold the common snapshot on the target. Use `--no-bookmarks` to use holds on the source instead, like older versions did. (Use `--hold-format` to specify the name of the hold, and `--no-holds` to disable holds completely)
+
+Just before the first snapshot is transferred, we do a rollback, if `--rollback` is specified.
+
+If it's an initial transfer that created a new target dataset, we try to [automount](Mounting) the target after the first snapshot is transferred.
+
+We destroy obsolete snapshots from the planning phase as soon as possible. (`--no-thinning` effectively disables this )
+
+#### Extra transfer options
+
+
+* `--ignore-transfer-errors`: Ignore ZFS transfer errors. It still checks if received filesystem exists. This is useful to ignore some acltype errors.
+* `--clear-refreservation`: Filter "refreservation" property. Recommended to save space. Same as `--filter-properties` refreservation.
+* `--clear-mountpoint`:  Set property `canmount=noauto` for new datasets.  Recommended, prevents mount conflicts. Same as `--set-properties canmount=noauto`. Also see [Mounting](Mounting)
+* `--strip-path N`: Number of directories to strip from target path. An example is given in the Getting started guide.
+* `--force`: Use `zfs -F` option to force overwrite/rollback. Useful with `--strip-path=1`. Use with care!
+
+## Step 4: Handle missing datasets
+
+Datasets that are missing or deselected, but still exist in the target-path are called missing datasets.
+
+The handling of those is described [here](Thinner#destroying-missing-datasets) (`--destroy-missing` )
+
+
+## Thinner
+
+The thinner decides when a snapshot is obsolete. Look at [Thinner](Thinner) for more info. (`--keep-source` and `--keep-target`)
+
+
+## Running without root
+
+In order to run zfs-autobackup without root permissions, you'll need to set a few ZFS permissions. The permissions required differ for receiving and sending.
+
+On the machine you want to sync the dataset from, you'll need these permissions:
+
+```console
+root@source:~# zfs allow -u localuser mount,send,hold,snapshot,destroy,release,bookmark rpool
+```
+
+(The `bookmark` permission is needed since version 4.0, unless you use `--no-bookmarks`)
+
+On the receiving side, you need these:
+
+```console
+root@target:~# zfs allow -u remoteuser compression,mountpoint,create,mount,receive,rollback,destroy,release,hold,userprop,readonly,canmount,dedup tank/backups/rpool
+```
+
+Depending on your use-case, you can always try to restrict these permissions further.
+
+### /dev/zfs permissions
+
+On some distributions like Alpine linux, you will need to change the permissions of /dev/zfs, so that regular users can write to it. This is safe, since the zfs kernel module handles access restrictions internally. (via zfs allow etc)
+
+If you have trouble, make sure to check this, or just fix it with `chmod 666 /dev/zfs`
+
+

--- a/wiki/Monitoring.md
+++ b/wiki/Monitoring.md
@@ -1,0 +1,27 @@
+## Monitoring if zfs-autobackup succeeds
+
+On completion, zfs-autobackup returns an exit code:
+
+* `0`: Everything went fine, no important errors.
+* `x`: Snapshotting was ok, but there are `x` datasets that aborted with a fatal error.
+* `255`: Wrong options or other major failure, probably nothing succeeded. 
+
+### Output
+
+Without `--verbose` or `--debug`, zfs-autobackup only echos (zfs) errors and warnings to stderr. Complete silence means everything is fine.
+
+So if you stick it in a crontab it should only mail you if something is wrong.
+
+If it detects a tty it will output progress updates to stdout.
+
+## Monitoring example with Zabbix-jobs
+
+You can monitor backups by using my zabbix-jobs script. (<https://github.com/psy0rz/stuff/tree/master/zabbix-jobs>)
+
+Put this command directly after the zfs_backup command in your cronjob:
+
+```console
+zabbix-job-status backup_smartos01_fs1 daily $?
+```
+
+This will update the zabbix server with the exit code and will also alert you if the job didn't run for more than 2 days.

--- a/wiki/Mounting.md
+++ b/wiki/Mounting.md
@@ -1,0 +1,76 @@
+## Mounting ZFS datasets
+
+TLDR: Always use `--clear-mountpoint` unless you have good reasons not to.
+
+When a target dataset is mounted, in some cases ZFS might modify a parent dataset. 
+
+On the next backup run you'll get this dreaded message:
+
+```
+ cannot receive incremental stream: destination has been modified since most recent snapshot
+```
+
+If you then proceed to use `--rollback` or `--force` things might get weird:  ZFS will yank away the underlying directory, while its still mounted. If you use `ls` on a folder you wont see the mountpoint, but you can still access it.
+
+**In version 3.3 of zfs-autobackup this will seem to be more prominent, because mounting has improved. Normally this problem would happen later after you reboot or zfs mount -a**
+
+## Possible causes
+
+Consider this pool:
+
+```
+dataset:         mounted at:
+pool             /pool
+pool/sub1        /pool/sub1
+pool/sub1/sub2   /pool/sub1/sub2
+```
+
+This means the following mount-point directories where created:
+* The root filesystem has a directory named `pool`
+* Dataset `pool` has a directory named `sub1`
+* Dataset `pool/sub1` has a directory named `sub2`
+
+### Target side 
+
+Now if we only select `pool` and `pool/sub1/sub2` to backup, then the target server will look like this:
+
+```
+dataset:                mounted at:
+backup/pool             /pool
+backup/pool/sub1/sub2   /pool/sub1/sub2
+```
+
+This means the following mount-point directories are needed:
+* The root filesystem has a directory named `pool`
+* Dataset `backup/pool` has a directory named `sub1/sub2` !
+
+So `sub2` will be created in `sub1`, thus modifying the dataset!
+
+## Solution
+
+The best solution is to use the `--clear-mountpoint` option of zfs-autobackup. This will set canmount=noauto on newly received datasets.
+
+When you need to access the data you can use zfs mount to mount just one dataset and leave the rest untouched.
+
+**Note that this option also prevents bootproblems, in case a dataset has a mountpoint that conflicts with existing mountpoints.**
+
+### Fix the problem manually
+
+If you forgot to use --clear-mount, you can use some shell magic to fix it, for example for `test_target1`:
+
+```console
+ # zfs list -H -oname -r test_target1|xargs zfs set canmount=noauto
+ # zfs list -H -oname -r test_target1|xargs -n1 zfs umount
+```
+
+After this you will have to use the `--rollback` option once to remove all the changes.
+
+## Workarounds
+
+These are some workarounds if cant use the method above, but they are not a perfect solution:
+
+* Create the needed directories on the source side.
+* Just use `--rollback` (or `--force`) all the time. This is kind of ugly and will confuse mountpoints and give various problems.
+* Set the `readonly=on` property on the target dataset. This prevents modification, but doesn't allow you to mount some datasets.
+* Manualy change the mountpoint of a target dataset to something like /mnt.
+

--- a/wiki/Performance.md
+++ b/wiki/Performance.md
@@ -1,0 +1,93 @@
+## Performance tips
+
+Depending on your situation, these performance tips may help a lot.
+
+## Speeding up SSH
+
+You can make your ssh connections persistent and greatly speed up zfs-autobackup:
+
+On the server that initiates the backup add this to your ~/.ssh/config:
+
+```console
+Host *
+    ControlPath ~/.ssh/control-master-%r@%h:%p
+    ControlMaster auto
+    ControlPersist 3600
+```
+
+Thanks @mariusvw :)
+
+### Direct TCP network transfer
+
+If ssh-encryption performance is still too slow for your use-case, you can do a direct unencrypted transfer via tcp ip:
+
+Use something like this:
+```console
+zfs-autobackup ... --send-pipe "nc server_name 8023" --recv-pipe "nc -l -p 8023"
+```
+
+This will pipe the data through netcat on the specified port. (You can use any transfer program you want this way)
+
+Note that only the actual transfer of the ZFS-data during zfs send/recv is done via this, it still requires SSH for all the other stuff.
+
+Also see: https://github.com/psy0rz/zfs_autobackup/issues/15#issuecomment-1043753454
+
+## Buffering and compression
+
+Also it might help to use the `--buffer` option to use IO buffering during the data transfer. 
+
+This might speed up things since it smooths out sudden IO bursts that are frequent during a zfs send or recv.
+
+If you have a slow link and compressible data, look at the `--compress` option.
+
+Also see [[Piping]]
+
+## Less zfs commands
+
+You can make zfs-autobackup use less commands and IO per snapshot transfer by:
+
+* `--no-holds`: to prevent the hold/release commands.
+* `--allow-empty`: to prevent commands to figure out if a snapshot would be empty.
+* `--no-guid-check`: dont check if common snapshots have the same guid.
+* `--clear-mountpoint`: not mounting the dataset on the target saves time.
+
+## Disable progress (ZFS bug)
+
+There is actually a performance regression in ZFS version 2: https://github.com/openzfs/zfs/issues/11560 
+
+This bug will delay each transfer by 1 second. This is a problem if you have lots of small transfers.
+
+Use --no-progress as workaround.
+
+## Some statistics
+
+To get some idea of how fast zfs-autobackup is, I did some test on my laptop, with a SKHynix_HFS512GD9TNI-L2B0B disk. I'm using zfs 2.0.2.  
+
+I created 100 empty datasets and measured the total runtime of zfs-autobackup. I used --no-holds, --allow-empty and ssh ControlMaster.
+
+* without ssh: 15 seconds. (>6 datasets/s)
+* either ssh-target or ssh-source=localhost: 20 seconds (5 datasets/s)
+* both ssh-target and ssh-source=localhost: 24 seconds (4 datasets/s)
+
+To be bold I created 2500 datasets, but that also was no problem. So it seems it should be possible to use zfs-autobackup with thousands of datasets.
+
+If you need more performance let me know.
+
+## TCP tuning
+
+By default, the linux kernel uses `cubic` as the TCP Congestion Control protocol. This is extremely good for _almost_ all situations, except for moving huge amounts of data over the public internet where you can have brief bursts of congestion (and therefore packet loss).
+
+Changing this to `scaleable` makes TCP sessions recover much faster from packet loss, and return to the full speed available without the extended recovery of the normal `cubic` protocol.
+
+If you're sending data over the internet, this setting might help:
+
+/etc/sysctl.d/60-send-bulk-tcp.conf:
+```
+# Recovers rapidly from congestion
+net.ipv4.tcp_congestion_control = scalable
+```
+
+More info: https://en.wikipedia.org/wiki/Scalable_TCP
+
+(thanks @xrobau)
+

--- a/wiki/Piping.md
+++ b/wiki/Piping.md
@@ -1,0 +1,66 @@
+During transfer the data will be piped from the source to the target.
+
+Its possible to add certain operations to this pipe.
+
+## Transfer buffering
+
+
+The `--buffer` option might help since it acts as an IO buffer: zfs send can vary wildly between completely idle and huge bursts of data. When zfs send is idle, the buffer will continue transferring data to the other side.
+
+This needs the mbuffer command on both sides.
+
+You can tune the chunk size that mbuffer uses with `--buffer-chunk-size`. (version 4.0 and higher)
+## Compression
+
+If you're transferring over a slow link it might be useful to use `--compress`. This will compress the data before sending, so it uses less bandwidth. 
+
+An alternative to this is to use `--zfs-compressed`: This will transfer blocks that already have compression intact. 
+
+* `--compress` will usually compress much better but uses much more resources.
+* ` --zfs-compressed` uses the least resources, but can be a disadvantage if you want to use a different compression method on the target.
+
+Dont use both options at the same time, since its probably wont help.
+
+By default `--compress` uses pigz-fast. Use `--compress=...` to select a specific compressor:
+
+* `pigz-fast`: Uses pigz -3
+* `pigz-slow`: Uses pigz -9
+* `gzip`: Uses gzip -3 and zcat.
+* `zstd-fast`: Uses zstdmt -3
+* `zstd-slow`: Uses zstdmt -19
+* `zstd-adapt`: Uses zstdmt --adapt
+* `xz`: Uses xz
+* `lzo`: Uses lzop
+* `lz4`: Uses lz4
+
+Offcourse the specific compressors need to be installed on both sides.
+## Rate limiting
+
+If you want to limit the datarate, try using the `--rate` option. This is usefull to not saturate a slow uplink or do reduce IO load.
+
+This needs the mbuffer command on the sending side.
+
+## Custom pipes
+
+It's also possible to add custom send or receive pipes with `--send-pipe` and `--recv-pipe`.
+
+This way you can pipe the data through and custom compressor or command you like.
+
+## Putting it all together
+
+These options all work together, when all options are active:
+
+Pipe on the the sending side:
+
+```
+zfs send | buffer | custom send pipes | compression | transfer rate limiter | ssh
+```
+
+On the receiving side:
+```
+decompression | custom recv pipes | buffer | zfs recv
+```
+
+The buffer on the receiving side is only added if its on a different host.
+
+Also zfs-autobackup will warn you if you do something useless, like using --compress for local transfers on the same host.

--- a/wiki/PrePost.md
+++ b/wiki/PrePost.md
@@ -1,0 +1,51 @@
+## Running custom commands before and after snapshotting
+
+You can run commands before and after the snapshot to freeze databases for example, to make the on-disk data consistent before snapshotting.
+
+## When is this needed?
+
+ZFS snapshots are atomic per pool. There wont be any corruption if something tries to write during the making of a snapshot. 
+
+If you restore a snapshot, the application will just think the server (or application) had a regular crash.
+
+Most modern databases and applications can handle this fine, so usually freezing isnt needed in that case. 
+
+Note that if you use multiple pools, the snapshots are only atomic per pool. 
+## Method 1: Use snapshot mode
+
+Its possible to use zfs-autobackup in snapshot-only mode. This way you can just create a script that contains the pre and post steps:
+
+```console
+#freeze stuff
+some-freeze-command
+
+#make snapshot
+zfs-autobackup backup1
+
+#unfreeze stuff
+some-unfreeze-command
+
+#make backup
+zfs-autobackup backup1 --no-snapshot --ssh-target backupserver backups/db1
+```
+
+This has the disadvantage that you might have to do the error handling yourself. Also if the source is remote, you have to use the correct ssh command and escaping as well.
+
+## Method 2: Use --pre-snapshot-cmd and --post-snapshot-cmd
+
+With this method, zfs-autobackup will handle the pre and post execution for you.
+
+For example:
+
+```sh
+zfs-autobackup \
+ --pre-snapshot-cmd 'some-freeze-command'\
+ --post-snapshot-cmd 'some-unfreeze-command'\
+ --ssh-target backupserver backups/db1
+```
+
+The way this works:
+
+* The pre and post commands are always executed on the source side. (via ssh if needed)
+* If a pre-command fails, it will immediately execute the post-commands and exit with an error code.
+* All post-commands are always executed. Even if the pre-commands or actual snapshot have failed. This way you can be sure that stuff is always cleaned up and unfreezed.

--- a/wiki/Problems.md
+++ b/wiki/Problems.md
@@ -1,0 +1,65 @@
+# Common problems you might encounter
+
+## It keeps asking for my SSH password
+
+You forgot to setup automatic login via SSH keys, look in the example how to do this.
+
+
+## "cannot receive incremental stream: destination has been modified since most recent snapshot"
+
+This means your target dataset has been modified somehow.
+
+Make sure you read how [[Mounting]] works.
+
+ * You can use `--rollback` to automatically rollback such changes. 
+ * Set the `readonly` property of the target filesystem to on. This prevents all modifications on the target side.  Note that readonly prevents changes to the CONTENTS of the dataset directly. Its still possible to receive new datasets and manipulate properties etc.
+ * Always use `--clear-mountpoint`, see [[Mounting]]
+
+
+## "cannot receive incremental stream: invalid backup stream"
+
+This usually means you've created a new snapshot on the target side during a backup. If you restart zfs-autobackup, it will automaticly abort the invalid partially received snapshot and start over.
+
+## "internal error: Invalid argument"
+
+In some cases (Linux -> FreeBSD) this means certain properties are not fully supported on the target system.
+
+Try using something like: --filter-properties xattr or --ignore-transfer-errors. 
+
+##  zfs receive fails, but snapshot seems to be received successful.
+
+This happens if you transfer between different Operating systems/zfs versions or feature sets.
+
+Try using the --ignore-transfer-errors option. This will ignore the error. It will still check if the snapshot is actually received correctly.
+
+## "cannot receive incremental stream: kernel modules must be upgraded to receive this stream."
+
+This happens if you forget to use --encrypt, while the target datasets are already encrypted. (Very strange error message indeed)
+
+## "dataset is busy"
+
+If you try to destroy a snapshot and its busy, there might be multiple reasons, but dont forget to check if the snapshot has holds with:
+
+> zfs holds `zpool/fs1@snapshot1`
+
+Release it with zfs release.
+
+Use --no-holds in zfs-autobackup if you dont want to use holds.
+
+Note: Since version 4.0 this problem mostly went away on the source side, because zfs-autobackup uses bookmarks there instead of holds. See [[Common-snapshots-and-holds]]
+
+## "--exclude-received is no longer needed"
+
+The `--exclude-received` option is removed in version 4.0: zfs-autobackup now always filters all the `autobackup:...` properties for newly received datasets, which solves the recursive replication problem in a better way.
+
+Remove the option from your scripts. To get rid of existing properties on the target do this one time:
+
+> zfs inherit -r autobackup:backup1 pool/backup1
+
+## Other problems
+
+ * Feel free to ask questions about zfs-autobackup here: https://github.com/psy0rz/zfs_autobackup/discussions
+
+ * If you found a bug or want to request a feature: https://github.com/psy0rz/zfs_autobackup/issues
+
+ * For more general questions go to the excellent subreddit at https://reddit.com/r/zfs

--- a/wiki/Thinner.md
+++ b/wiki/Thinner.md
@@ -1,0 +1,120 @@
+## Thinning out obsolete snapshots
+
+The thinner is the thing that destroys old snapshots on the source and target.
+
+The thinner operates "stateless": There is nothing in the name or properties of a snapshot that indicates how long it will be kept. Everytime zfs-autobackup runs, it will look at the timestamp of all the existing snapshots. From there it will determine which snapshots are obsolete according to your schedule. The advantage of this stateless system is that you can always change the schedule.
+
+Another advantage is if your backup has failed for a longer time: It might have "missed" your monthly backup date, but the thinner then still holds the snapshot thats closest to the intended target date. 
+
+## Which snapshots is it operating on?
+
+A snapshot name should match `--snapshot-format` to be considered for deletion. 
+
+This means that:
+* On the source, only snapshots on datasets that are **selected** are considered.
+* On the target, **all** snapshots are considered recursively. 
+
+## Thinning schedule
+
+The thinning schedule is specified via the `--keep-source=...` and `--keep-target=...` parameters.
+
+The default thinning schedule is: `10,1d1w,1w1m,1m1y`.
+
+The schedule consists of multiple rules separated by a `,`
+
+A plain number specifies how many snapshots you want to always keep, regardless of time or interval.
+
+The format of the other rules is: `<Interval><TTL>`.
+
+* Interval: The minimum interval between the snapshots. Snapshots with intervals smaller than this will be destroyed.
+* TTL: The maximum time to life time of a snapshot, after that they will be destroyed.
+* These are the time units you can use for interval and TTL:
+  * `y`: Years
+  * `m`: Months
+  * `d`: Days
+  * `h`: Hours
+  * `min`: Minutes
+  * `s`: Seconds
+
+Since this might sound very complicated, the `--verbose` option will show you what it all means:
+
+```console
+[root@backup ~]# zfs-autobackup -v offsite1 --keep-source=10,1d1w,1w1m,1m1y
+  zfs-autobackup v3.1.1 - (c)2021 E.H.Eefting (edwin@datux.nl)
+  
+  Selecting dataset property : autobackup:offsite1
+  Snapshot format            : offsite1-%Y%m%d%H%M%S
+  Hold name                  : zfs_autobackup:offsite1
+  
+  #### Source settings
+  [Source] Datasets are local
+  [Source] Keep the last 10 snapshots.
+  [Source] Keep every 1 day, delete after 1 week.
+  [Source] Keep every 1 week, delete after 1 month.
+  [Source] Keep every 1 month, delete after 1 year.
+...
+```
+
+A snapshot will only be destroyed if it not needed anymore by ANY of the rules.
+
+You can specify as many rules as you need. The order of the rules doesn't matter.
+
+Keep in mind its up to you to actually run zfs-autobackup often enough: If you want to keep hourly snapshots, you have to make sure you at least run it every hour.
+
+However, its no problem if you run it more or less often than that: The thinner will still keep an optimal set of snapshots to match your schedule as close as possible.
+
+If you want to keep as few snapshots as possible, just specify 0. (`--keep-source=0` for example)
+
+Since version 4.0 a `--keep-source=0` really keeps nothing on the source: the common snapshot is replaced by a [bookmark](Common-snapshots-and-holds), which takes up almost no space. (In older versions the common snapshot was always kept) It also automatically implies `--min-change=0`, since there is no snapshot left to compare changes against.
+
+If you want to keep ALL the snapshots, just specify a high number.
+
+## Destroying missing datasets
+
+When a dataset has been destroyed or deselected on the source, but still exists on the target we call it a missing dataset. Missing datasets will be still thinned out according to the schedule. (Unless `--no-thinning` is used)
+
+The final snapshot will never be destroyed, unless you specify a **deadline** with the `--destroy-missing` option:
+
+In that case it will look at the last snapshot we took and determine if is older than the deadline you specified. e.g: `--destroy-missing 30d` will start destroying things 30 days after the last snapshot.
+
+### After the deadline
+
+When the deadline is passed, all our snapshots, except the last one will be destroyed. Irregardless of the normal thinning schedule.
+
+The dataset has to have the following properties to be finally really destroyed:
+
+* The dataset has no direct child-filesystems or volumes.
+* The only snapshot left is the last one created by zfs-autobackup.
+* The remaining snapshot has no clones.
+
+## Technical details about the Thinner
+
+Only read this section if you want to exactly know whats going on.
+
+We will give a practical example of how the thinner operates.
+
+Say we want have 3 thinner rules:
+
+* We want to keep daily snapshots for 7 days.
+* We want to keep weekly snapshots for 4 weeks.
+* We want to keep monthly snapshots for 12 months.
+
+So far we have taken 4 snapshots at random moments:
+
+![thinner example](https://raw.githubusercontent.com/psy0rz/zfs_autobackup/master/doc/thinner.png)
+
+For every rule, the thinner will divide the timeline in blocks and assign each snapshot to a block.
+
+A block can only be assigned one snapshot: If multiple snapshots fall into the same block, it only assigns it to the oldest that we want to keep.
+
+The colors show to which block a snapshot belongs:
+
+* Snapshot 1: This snapshot belongs to daily block 1, weekly block 0 and monthly block 0. However the daily block is too old.
+* Snapshot 2: Since weekly block 0 and monthly block 0 already have a snapshot, it only belongs to daily block 4.
+* Snapshot 3: This snapshot belongs to daily block 8 and weekly block 1.
+* Snapshot 4: Since daily block 8 already has a snapshot, this one doesn't belong to anything and can be deleted right away. (it will be keeped for now since its the last snapshot)
+
+zfs-autobackup will re-evaluate this on every run: As soon as a snapshot doesn't belong to any block anymore it will be destroyed.
+
+Snapshots on the source that still have to be send to the target wont be destroyed off course. (If the target still wants them, according to the target schedule)
+

--- a/wiki/Upgrading-to-v4.0.md
+++ b/wiki/Upgrading-to-v4.0.md
@@ -1,0 +1,48 @@
+# Upgrading to version 4.0
+
+Version 4.0 changes some things in how zfs-autobackup operates by default. This page lists what changed and what you might have to do.
+
+**TLDR:** Upgrading is safe: existing backups just keep working and you usually dont have to change anything. The only hard change is `--exclude-received`: remove it from your scripts.
+
+## Bookmarks instead of holds on the source
+
+After a successful transfer, the source now creates a ZFS bookmark of the common snapshot, instead of holding the snapshot. This means the source snapshot itself can be destroyed by the [Thinner](Thinner), saving space. With `--keep-source=0` almost nothing is kept on the source anymore.
+
+* Existing backups will automatically start using bookmarks on the next run.
+* If a pool doesn't support bookmarks, zfs-autobackup warns you and falls back to holds.
+* Use `--no-bookmarks` to get the old behaviour.
+* If you run without root, the user needs the `bookmark` zfs-permission on the source. See [Running without root](Manual#running-without-root)
+
+More info: [[Common-snapshots-and-holds]]
+
+## --exclude-received is removed
+
+zfs-autobackup now always filters **all** `autobackup:...` properties when receiving datasets. This solves the recursive replication problem that `--exclude-received` was for, so the option is removed. Using it results in an error.
+
+* Remove `--exclude-received` from your scripts.
+* To get rid of existing autobackup-properties on the target, do this one time: `zfs inherit -r autobackup:backup1 pool/backup1`
+
+## Clone support
+
+Source datasets that are ZFS clones now keep their clone relationship on the target, so the target stays just as space-efficient as the source. Use `--no-clone` for the old behaviour. More info: [[Clones]]
+
+## Better handling of missing common snapshots
+
+If there is no common snapshot or bookmark, you no longer have to destroy the target dataset and its children manually. zfs-autobackup now tells you exactly what to do: use `-F` to overwrite the target dataset, or `--destroy-incompatible -F` if it also has snapshots in the way.
+
+Also, zfs-autobackup can now find the common snapshot via a GUID-search, even if the snapshot or bookmark names dont match. This makes migrating from other snapshot tools much easier.
+
+## Snapshot tags
+
+You can add an administrative tag to snapshot names with `--tag`. Tags are ignored when matching and thinning snapshots. See [Tags](Manual#tags)
+
+If your snapshot-format or existing snapshot names contain the default tag-seperator `__`, you might have to change the seperator with `--tag-seperator`.
+
+## Other changes
+
+* `--exclude-snapshot-pattern`: ignore snapshots matching a regular expression.
+* `--buffer-chunk-size`: tune the mbuffer chunk size, also see [[Piping]].
+* `--keep-source=0` now automatically implies `--min-change=0`, which is a significant speedup if you have lots of datasets.
+* Better progress output: you now see counters like `[5/100]` and the number of failed datasets while it runs.
+* `--decrypt` now warns that properties will not be sent over for decrypted datasets, due to a ZFS bug. See [[Encryption]]
+* Python 2 support is dropped, the minimum python version is now 3.2.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+Sponsored by: JetBrains

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,23 @@
+zfs-autobackup:
+
+* [Introduction (README.md)](../blob/master/README.md)
+* [Getting started](Home)
+* [Full manual](Manual)
+* [Upgrading to v4.0](Upgrading-to-v4.0)
+* [Mounting backup datasets](Mounting)
+* [Performance tips (recommended)](Performance)
+* [Common problems and errors](Problems)
+* [Thinning out obsolete snapshots](Thinner)
+* [Common snapshots, bookmarks and holds](Common-snapshots-and-holds)
+* [Replicating ZFS clones](Clones)
+* [Handling ZFS encryption](Encryption)
+* [Transfer buffering, compression and rate limiting.](Piping)
+* [Custom Pre- and post-snapshot commands](PrePost)
+* [Monitoring](Monitoring)
+
+Examples:
+* [Proxmox cluster backups](Example%20Proxmox)
+* [Backup to rsync.net](Backup-to-rsync.net-via-ZFS)
+* [Setting up development environment](Development)
+
+

--- a/wiki/zfs-check.md
+++ b/wiki/zfs-check.md
@@ -1,0 +1,133 @@
+# Checking backups with zfs-check
+
+This tool is part of zfs-autobackup v3.2-alpha2 and higher. 
+
+Get it with:
+```
+pip install zfs-autobackup --pre --upgrade
+```
+
+## What does it do?
+
+zfs-check is a tool to generate checksum streams from zfs datasets. (it also can be used on regular block devices and files)
+
+Its kind of like sha1sum, but incremental: It generates a sha1 hash per "chunk" of data. This allows you to use it on huge datasets and only do a partial checks of the data.
+
+## Why?
+
+A tool like this wouldn't seem necessary for ZFS: ZFS has full check summing, so you can be 100% sure the data doesn't get corrupted, right?
+
+While this is true to a certain extend, it IS possible that data gets corrupted during transfer with zfs send/recv. This can happen because of certain bugs in ZFS. For example: https://github.com/openzfs/zfs/issues/12762 and https://github.com/openzfs/zfs/issues/6224
+
+In such cases the checksums are still OK, but they are of the wrong (corrupt) data.
+
+So a tool to actually compare the data of 2 datasets was needed, hence zfs-check.
+
+## How to use it?
+
+In its simplest form you can just use it on a directory like this:
+
+```shell
+[root@pve1 ~]# zfs-check /bin --verbose |head -20
+  zfs-check v3.2-alpha2 - (c)2022 E.H.Eefting (edwin@datux.nl)
+  
+  Target               : /bin
+  Block size           : 4096 bytes
+  Block count          : 25600
+  Effective chunk size : 104857600 bytes
+  Skip chunk count     : 0 (checks 100.00% of data)
+  
+smbtree	0	cec00f01df1064a98640e01b50c4030259c655bc
+ls	0	605d772c98dd91c4df9a9200e63c5edf10cff4ce
+cifsdd	0	11348b768b5f14234863c02392dcbe749d34bf91
+dh_bash-completion	0	9d17e0e071892ef43f1ae3fdb5abd40b5bb45252
+swtpm_localca	0	83b427c1ae0d91d46cd49db8ae31e2425e5de55a
+dpkg-mergechangelogs	0	13ec450b69b525bc510bcf15f2409a647928fc43
+true	0	f490cefeec06ba345a5e53ec9814a9763a3330e9
+...
+```
+
+The 0 in this output means its the checksum of chunk zero of each file. Since the default chunksize is 100MB, all the small files in this example have just one chunk.
+
+### Comparing with --check
+
+The output of this can then be used as input on another zfs-check. In this example we detected an error:
+
+```shell
+[root@pve1 ~]# zfs-check /bin > checksums
+[root@pve1 ~]# zfs-check /bin --check checksums
+aa-enabled: Chunk 0 failed: c2a2be25e6c3a5d89005028ea37a61771489710a c2a2be25e6c3a5d89005028ea37a61771489710f
+```
+
+It displays the expected sha1sum vs the actual sha1sum)
+
+## Using it on ZFS snapshots
+
+You can just specify a snapshot of a volume or filesystem. zfs-check will mount it and check it just like the above examples. (Use `--debug` if you want to see how it does this.)
+
+On a ZFS volume:
+```
+[root@pve1 ~]# zfs-check rpool/data/vm-101-disk-0@kantoor_offsite-20220308020453 
+0	87a193d73a27aceb38334eca51d180493c9a2348
+1	92559a75e61b021e6a3a351a6b241d7440b79d55
+2	6abb3ec919ccbe6ac36580cc43f34af80280ae18
+...
+```
+
+On a ZFS dataset:
+```
+[root@pve1 ~]# zfs-check rpool/data/subvol-104-disk-0@kantoor_offsite-20220308020453 
+run/resolvconf/resolv.conf	0	c3f9736e9af7bd0885578859a50b205c8fa5fc8e
+run/resolvconf/interface/original.resolvconf	0	c3f9736e9af7bd0885578859a50b205c8fa5fc8e
+run/samba/names.tdb	0	3dddf16c3899dcf79c0beb636520cc58c86c4ef2
+run/samba/gencache_notrans.tdb	0	7c1499d1a78a24d08dbeaeb7bf93ffdc0b0fac41
+run/samba/mutex.tdb	0	3dddf16c3899dcf79c0beb636520cc58c86c4ef2
+run/samba/upgrades/smb.conf	0	ffc2469dd94b7772c2f1689a43e5bacf62bdd0d1
+run/samba/msg.lock/13960	0	21c27e175354df9df55b9b3d3500482b2ea99161
+run/samba/msg.lock/6124	0	d6b22ab7ca0ac99d3d74eb58499ccfd2fc85c426
+...
+```
+
+## Using it to compare a remote and local ZFS dataset
+
+You can use it via a simple SSH pipe to compare to datasets:
+```shell
+[root@pve1 ~]# zfs-check rpool/data/vm-101-disk-0@offsite-20220308020453 | ssh backupserver1 "zfs-check backup/pve1/rpool/data/vm-101-disk-0@offsite-20220308020453 --check"
+
+```
+
+## Only checking a small sample of the total data
+
+You can use the `--skip` option to skip a certain amount of chunks. To only check 10% of your data use --skip 9. (It will check 1 block and then skip 9 blocks)
+
+```shell
+[root@pve1 ~]# zfs-check rpool/data/vm-101-disk-0@offsite-20220308020453 --skip 9 --verbose
+  zfs-check v3.2-alpha2 - (c)2022 E.H.Eefting (edwin@datux.nl)
+  
+  Target               : rpool/data/vm-101-disk-0@kantoor_offsite-20220308020453
+  Block size           : 4096 bytes
+  Block count          : 25600
+  Effective chunk size : 104857600 bytes
+  Skip chunk count     : 9 (checks 10.00% of data)
+  
+0	87a193d73a27aceb38334eca51d180493c9a2348
+10	2c2ceccb5ec5574f791d45b63c940cff20550f9a
+20	2c2ceccb5ec5574f791d45b63c940cff20550f9a
+30	6fdee2a737a0b4db519a70dc2ecd765a90a10bce
+```
+
+Normally you use this on the "generating" side.
+
+You can also use it on the "checking" side: It will then just skip this number of hashes. This is usefull if you already generated a 100% list of checksums, but you only want to compare a smaller sample of it.
+
+Note: Keep in mind that if you use --skip on both sides, it will skip 2 times. If you use --skip=9 on both sides, the sender will only send 10% and the checker will only check 10% of that amount. (resulting in a coverage of 1%)
+
+
+## Using it automaticly with zfs-autoverify
+
+**Work in progress**
+
+This tool will use zfs-check to automaticly verify your backups that where made with zfs-autobackup.
+
+
+ 

--- a/zfs_autobackup/CliBase.py
+++ b/zfs_autobackup/CliBase.py
@@ -10,7 +10,7 @@ class CliBase(object):
     Overridden in subclasses that add stuff for the specific programs."""
 
     # also used by setup.py
-    VERSION = "3.3-beta.3"
+    VERSION = "3.3-rc.1"
     HEADER = "{} v{} - (c)2022 E.H.Eefting (edwin@datux.nl)".format(os.path.basename(sys.argv[0]), VERSION)
 
     def __init__(self, argv, print_arguments=True):

--- a/zfs_autobackup/CliBase.py
+++ b/zfs_autobackup/CliBase.py
@@ -10,7 +10,7 @@ class CliBase(object):
     Overridden in subclasses that add stuff for the specific programs."""
 
     # also used by setup.py
-    VERSION = "3.3-rc.1"
+    VERSION = "3.3"
     HEADER = "{} v{} - (c)2022 E.H.Eefting (edwin@datux.nl)".format(os.path.basename(sys.argv[0]), VERSION)
 
     def __init__(self, argv, print_arguments=True):

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -110,6 +110,12 @@ class ZfsAutobackup(ZfsAuto):
         group.add_argument('--zfs-compressed', action='store_true',
                            help='Transfer blocks that already have zfs-compression as-is.')
 
+        group.add_argument('--clones', metavar='POLICY', default='never',
+                           choices=('never', 'simple'),
+                           help='Clones support. (The default policy "never" expands clones into full independent datasets. '
+                                '"simple" tries to reproduce the clone when the origin snapshot is already copied '
+                                'in the same target root)')
+
         group = parser.add_argument_group("Data transfer options")
         group.add_argument('--compress', metavar='TYPE', default=None, nargs='?', const='zstd-fast',
                            choices=compressors.choices(),
@@ -399,6 +405,7 @@ class ZfsAutobackup(ZfsAuto):
                                               decrypt=self.args.decrypt, encrypt=self.args.encrypt,
                                               zfs_compressed=self.args.zfs_compressed, force=self.args.force,
                                               guid_check=not self.args.no_guid_check,
+                                              clones=self.args.clones,
                                               make_target_name=lambda source_dataset: self.make_target_name(source_dataset))
             except Exception as e:
 

--- a/zfs_autobackup/ZfsAutobackup.py
+++ b/zfs_autobackup/ZfsAutobackup.py
@@ -397,7 +397,9 @@ class ZfsAutobackup(ZfsAuto):
                                               destroy_incompatible=self.args.destroy_incompatible,
                                               send_pipes=send_pipes, recv_pipes=recv_pipes,
                                               decrypt=self.args.decrypt, encrypt=self.args.encrypt,
-                                              zfs_compressed=self.args.zfs_compressed, force=self.args.force, guid_check=not self.args.no_guid_check)
+                                              zfs_compressed=self.args.zfs_compressed, force=self.args.force,
+                                              guid_check=not self.args.no_guid_check,
+                                              make_target_name=lambda source_dataset: self.make_target_name(source_dataset))
             except Exception as e:
 
                 fail_count = fail_count + 1


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR contains updated wiki pages for the upcoming v4.0 release. The wiki files are in the `wiki/` subdirectory for review. Once approved, they will be pushed directly to the wiki repo.

### New pages
- **`Upgrading-to-v4.0.md`** — migration guide covering all behavioral changes (bookmarks, `--exclude-received` removal, clone support, tags, etc.)
- **`Clones.md`** — documents the new clone replication feature (`--no-clone`)

### Updated pages
- **`Common-snapshots-and-holds.md`** — rewritten around bookmarks as the new default; explains target-GUID tagging for multi-target backups, automatic fallback when pools lack bookmark support, improved offline-backup story
- **`Manual.md`** — updated usage block to v4.0-beta3 help output; new Tags section; updated Step 3.1/3.4 for bookmarks and clones; removed `--exclude-received`; added `bookmark` to the zfs-allow permissions for non-root users
- **`Encryption.md`** — note that `--decrypt` can't send properties due to OpenZFS bug #16275
- **`Problems.md`** — new entry for the `--exclude-received` removal with `zfs inherit -r` fix; "dataset is busy" note updated for bookmarks
- **`Thinner.md`** — `--keep-source=0` now truly keeps nothing (bookmark replaces common snapshot) and implies `--min-change=0`
- **`Piping.md`** — documented new `--buffer-chunk-size` option
- **`Home.md`**, **`_Sidebar.md`**, **`Example-Proxmox.md`** — minor updates for v4.0

## Test plan
- [ ] Review each wiki page in `wiki/` for accuracy and style
- [ ] Confirm `Upgrading-to-v4.0.md` covers all breaking changes
- [ ] Confirm `Clones.md` accurately describes fallback scenarios
- [ ] Approve and push to wiki repo (`https://github.com/psy0rz/zfs_autobackup.wiki.git`)
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDSAqC2su3981tB6cZCTCo)_